### PR TITLE
Soleng workshop updates - Correcting Links

### DIFF
--- a/workshops/dbcs/CloudWorkshop_DBCS_100.md
+++ b/workshops/dbcs/CloudWorkshop_DBCS_100.md
@@ -9,7 +9,7 @@ This is the first of several labs that are part of the Oracle Public Cloud Datab
 This lab will walk you through creating a new Database Cloud Service instance. After the database has been created, you will connect into the Database image using the ssh private key and familiarize yourself with the image layout. Next you will learn how to create an ssh configuration file that can be used to tunnel simultaneously multiple ports to a
 remote OPC instance. Using the tunnels, you will learn how to access various Database consoles.
  
-- To log issues and view the Lab Guide source, go to the [github oracle](https://github.com/pcdavies/DatabaseCloudService/tree/master/dbcs) repository.
+- To log issues and view the Lab Guide source, go to the [github oracle](https://github.com/oracle/learning-library/tree/master/workshops/dbcs) repository.
 
 ## Objectives
 

--- a/workshops/dbcs/CloudWorkshop_DBCS_200.md
+++ b/workshops/dbcs/CloudWorkshop_DBCS_200.md
@@ -6,7 +6,7 @@ Update March 28, 2017
 
 In this lab, you will explore some common use cases for moving your data from on-premises to the cloud. There are multiple options for solving this data movement challenge. In this lab, we will use SQL\*Developer and command line tools to clone and move a pluggable database from your on-premises database (your Virtual Machine) to your cloud database. You will also use standard Oracle Data Pump tools to export a schema from the on-premises database, and then import that data to your cloud database in a new schema. The final exercise uses the SQL Developer cart feature to quickly move data from the local database to the cloud using only the privileges of a normal schema owner.
 
-- To log issues and view the Lab Guide source, go to the [github oracle](https://github.com/pcdavies/DatabaseCloudService/tree/master/dbcs) repository.
+- To log issues and view the Lab Guide source, go to the [github oracle](https://github.com/oracle/learning-library/tree/master/workshops/dbcs) repository.
 
 ## Objectives
 


### PR DESCRIPTION
Links in the DBCS workshop were pointing to the wrong user's repository. 