### PR TITLE
Data Safe example and template changes

### DIFF
--- a/common/redwood-hol/index.html
+++ b/common/redwood-hol/index.html
@@ -33,7 +33,7 @@
         <nav class="hol-Nav">
             <button id="closeNav" class="hol-Nav-close" aria-label="Close Menu" title="Close Menu"><span
                     class="hol-Nav-closeIcon"></span></button>
-            <div class="hol-Nav-title">Lab Contents</div>
+            <div class="hol-Nav-title">Contents</div>
             <ul class="hol-Nav-list">
             </ul>
         </nav>

--- a/data-management-library/security/data-safe/workshop/analyze-alerts-audit-reports/analyze-alerts-audit-reports.md
+++ b/data-management-library/security/data-safe/workshop/analyze-alerts-audit-reports/analyze-alerts-audit-reports.md
@@ -16,11 +16,11 @@ To complete this lab, you need to have the following:
 - Audit collection started on your target database in Oracle Data Safe. If not, see **Provision Audit and Alert Policies**.
 
 ### Assumptions
-This lab assumes that you are already signed in to the Oracle Data Safe Console. If not, see [View a Registered Target Database](?lab=lab-1-view-registered-target-database), steps 1 and 2.
+This lab assumes that you are already signed in to the Oracle Data Safe Console. If not, see [View a Registered Target Database](?lab=lab-1-view-registered-target-database), Parts 1 and 2.
 
 Your data values may be different than those shown in the screenshots in this lab.
 
-## **STEP 1**: View and close alerts
+## **PART 1**: View and close alerts
 
 - In Oracle Data Safe Console, click the **Home** tab, and then click the **Alerts** tab.
 
@@ -120,7 +120,7 @@ Your data values may be different than those shown in the screenshots in this la
 
 
 
-## **STEP 2**: Analyze open alerts from the dashboard
+## **PART 2**: Analyze open alerts from the dashboard
 
 
 - Click the **Home** tab.
@@ -163,7 +163,7 @@ Your data values may be different than those shown in the screenshots in this la
   ![](./images/all-alerts-report-filtered.png " ")
 
 
-## **STEP 3**: View all audit records for the past week
+## **PART 3**: View all audit records for the past week
 
 - Click the **Reports** tab.
 
@@ -196,7 +196,7 @@ Your data values may be different than those shown in the screenshots in this la
 
 
 
-## **STEP 4**: View a summary of audit events collected and alerts raised
+## **PART 4**: View a summary of audit events collected and alerts raised
 
 - On the left, click **Summary Reports**, and then click **Audit Summary**.
 
@@ -249,7 +249,7 @@ Your data values may be different than those shown in the screenshots in this la
 
 
 
-## **STEP 5**: Create a failed logins report
+## **PART 5**: Create a failed logins report
 
 - Click the **Reports** tab.
 

--- a/data-management-library/security/data-safe/workshop/assess-db-config-users/assess-db-config-users.md
+++ b/data-management-library/security/data-safe/workshop/assess-db-config-users/assess-db-config-users.md
@@ -18,9 +18,9 @@ To complete this lab, you need to have the following:
 
 ### Assumptions
 
-This lab assumes that you are already signed in to the Oracle Data Safe Console. If not, see [View a Registered Target Database](?lab=lab-1-view-registered-target-database), steps 1 and 2.
+This lab assumes that you are already signed in to the Oracle Data Safe Console. If not, see [View a Registered Target Database](?lab=lab-1-view-registered-target-database), PARTs 1 and 2.
 
-## **STEP 1**: Run a Security Assessment job against a target database
+## **PART 1**: Run a Security Assessment job against a target database
 You can use Security Assessment to evaluate the current security state of your target databases and receive recommendations on how to mitigate the identified risks.
 
 - In the Oracle Data Safe Console, click the **Home** tab, and then click the **Security Assessment** tab.
@@ -31,12 +31,12 @@ You can use Security Assessment to evaluate the current security state of your t
 
    ![](./images/security-assess-target-database.png "fred")
 
-- While the assessment is running, continue to the next step.
+- While the assessment is running, continue to the next part.
 
   The assessment takes approximately 2-3 minutes to complete.
 
 
-## **STEP 2**: Run a User Assessment job against a target database
+## **PART 2**: Run a User Assessment job against a target database
 
 You can use User Assessment to identify user settings and risks on your target databases.
 
@@ -52,7 +52,7 @@ You can use User Assessment to identify user settings and risks on your target d
    ![](./images/user-assess-target-database.png " ")
 
 
-## **STEP 3**: Analyze the user assessment results
+## **PART 3**: Analyze the user assessment results
 
 - When the user assessment is completed, notice the following on the **User Assessment** page:
 
@@ -134,7 +134,7 @@ You can use User Assessment to identify user settings and risks on your target d
 
 
 
-## **STEP 4**: Analyze the security assessment results
+## **PART 4**: Analyze the security assessment results
 
 - Click the **Home** tab, and then click the **Security Assessment** tab.
 

--- a/data-management-library/security/data-safe/workshop/discover-mask-data/discover-mask-data.md
+++ b/data-management-library/security/data-safe/workshop/discover-mask-data/discover-mask-data.md
@@ -14,9 +14,9 @@ The following items are provided to you during the lab:
 - Oracle Data Safe enabled in a region of your tenancy
 - An Autonomous Transaction Processing (ATP) database and the password for the `ADMIN` user account
 
-## **STEP 1**: View sensitive data in your ATP database
+## **PART 1**: View sensitive data in your ATP database
 
-In this step, you use SQL Developer Web to query sensitive data in your ATP database. You can access SQL Developer Web in the ATP Console.
+In this part, you use SQL Developer Web to query sensitive data in your ATP database. You can access SQL Developer Web in the ATP Console.
 
 - From any browser, enter the following url:
 
@@ -24,7 +24,7 @@ In this step, you use SQL Developer Web to query sensitive data in your ATP data
 
 - If prompted, enter the tenancy name provided to you during the lab, and then click **Continue**.
 
-  Note: If you are signed in to Oracle Cloud Infrastructure on another tab, then you are not prompted to enter a tenancy name and can continue to the next step.
+  Note: If you are signed in to Oracle Cloud Infrastructure on another tab, then you are not prompted to enter a tenancy name and can continue to the next part.
 
     ![](./images/2019-08-13%2013_59_08-Oracle%20Cloud%20Infrastructure%20_%20Sign%20In.png " ")
 
@@ -107,17 +107,17 @@ In this step, you use SQL Developer Web to query sensitive data in your ATP data
 
   Data such as `employee_id`, `first_name`, `last_name`, `email`, `phone_number`, `hire_date`, `job_id`, `salary`, and `manager_id` are considered sensitive data and should be masked if shared with developers and testers.
 
-  Keep this tab open so that you can return to it later in step 4 when you view the masked data.
+  Keep this tab open so that you can return to it later in part 4 when you view the masked data.
 
      ![](./images/query-results.png " ")
 
 
 
-## **STEP 2**: Discover sensitive data by using Data Discovery
+## **PART 2**: Discover sensitive data by using Data Discovery
 
 The Data Discovery wizard generates a sensitive data model that contains sensitive columns in your target database. When working in the wizard, you select sensitive types that you want to discover in your target database.
 
-- Open a new tab in your browser, and enter the following url. Because you signed in to Oracle Cloud Infrastructure in step 1, you should automatically sign in. If not, sign in with your your tenancy name (if needed) and user credentials.
+- Open a new tab in your browser, and enter the following url. Because you signed in to Oracle Cloud Infrastructure in part 1, you should automatically sign in. If not, sign in with your your tenancy name (if needed) and user credentials.
 
   [https://console.us-ashburn-1.oraclecloud.com/a/tenancy](https://console.us-ashburn-1.oraclecloud.com/a/tenancy)
 
@@ -230,7 +230,7 @@ The Data Discovery wizard generates a sensitive data model that contains sensiti
 
 
 
-## **STEP 3**: Mask sensitive data by using Data Masking
+## **PART 3**: Mask sensitive data by using Data Masking
 The Data Masking wizard generates a masking policy for your target database based on a sensitive data model. In the wizard, you select the sensitive columns that you want to mask and the masking formats to use.
 
 - Click **Continue to mask the data**. The Data Masking wizard is displayed.
@@ -330,9 +330,9 @@ The Data Masking wizard generates a masking policy for your target database base
 
 
 
-## **STEP 4**: Validate the masked data in your ATP database
+## **PART 4**: Validate the masked data in your ATP database
 
-- Return to the browser tab for **SQL Developer Web**. You should still have your query results from STEP 1 in this lab. Take a moment to review the data.
+- Return to the browser tab for **SQL Developer Web**. You should still have your query results from part 1 in this lab. Take a moment to review the data.
 
    ![](./images/sql-developer-old-query-results.png " ")
 

--- a/data-management-library/security/data-safe/workshop/index.html
+++ b/data-management-library/security/data-safe/workshop/index.html
@@ -33,7 +33,7 @@
         <nav class="hol-Nav">
             <button id="closeNav" class="hol-Nav-close" aria-label="Close Menu" title="Close Menu"><span
                     class="hol-Nav-closeIcon"></span></button>
-            <div class="hol-Nav-title">Lab Contents</div>
+            <div class="hol-Nav-title">Contents</div>
             <ul class="hol-Nav-list">
             </ul>
         </nav>

--- a/data-management-library/security/data-safe/workshop/provision-audit-alert-policies/provision-audit-alert-policies.md
+++ b/data-management-library/security/data-safe/workshop/provision-audit-alert-policies/provision-audit-alert-policies.md
@@ -13,9 +13,9 @@ To complete this lab, you need to have the following:
 - A registered target database in Oracle Data Safe with sample audit data
 
 ### Assumptions
-This lab assumes that you are already signed in to the Oracle Data Safe Console. If not, see [View a Registered Target Database](?lab=lab-1-view-registered-target-database), steps 1 and 2.
+This lab assumes that you are already signed in to the Oracle Data Safe Console. If not, see [View a Registered Target Database](?lab=lab-1-view-registered-target-database), parts 1 and 2.
 
-## **STEP 1**: Provision audit and alert policies on a target database by using the Activity Auditing wizard
+## **PART 1**: Provision audit and alert policies on a target database by using the Activity Auditing wizard
 
 - In the Oracle Data Safe Console, click the **Home** tab, and then click the **Activity Auditing** tab.
 
@@ -67,7 +67,7 @@ This lab assumes that you are already signed in to the Oracle Data Safe Console.
 
 
   ![](./images/additional-audit-policies.png " ")
- 
+
 
 
 - Expand **Oracle Pre-defined Policies** to view the list of Oracle predefined audit policies available on your ATP database. By default, the following policies are provisioned:
@@ -81,7 +81,7 @@ This lab assumes that you are already signed in to the Oracle Data Safe Console.
   - `ORA_RAS_SESSION_MGMT`
   - `ORA_LOGON_FAILURES`
 
- 
+
   ![](./images/oracle-predefined-policies.png " ")
 
 - Notice that the **Center for Internet Security (CIS) Configuration** policy is provisioned and enabled by default.
@@ -101,7 +101,7 @@ This lab assumes that you are already signed in to the Oracle Data Safe Console.
   - **Database Parameter Changes**
   - **Audit Policy Changes**
   - **User Creation/Deletion**
-  - **User Entitlement Changes** 
+  - **User Entitlement Changes**
 
    ![](./images/selected-alert-policies.png " ")
 
@@ -149,13 +149,13 @@ This lab assumes that you are already signed in to the Oracle Data Safe Console.
 
 
 
-## **STEP 2**: View details for an audit trail
+## **PART 2**: View details for an audit trail
 
 On the **Audit Trails** page, you can manage all of the audit trails for your target databases.
 
 - In the **Collection State** column, click **COLLECTING** or **IDLE** if the audit data is collected.
 
-  Collection takes approximately 2 minutes. You can continue to the next step.
+  Collection takes approximately 2 minutes. You can continue to the next part.
 
 
   ![](./images/click-collecting-or-idle.png " ")
@@ -167,7 +167,7 @@ On the **Audit Trails** page, you can manage all of the audit trails for your ta
 
 
 
-## **STEP 3**: Enable a custom audit policy on a target database
+## **PART 3**: Enable a custom audit policy on a target database
 
 
 - Click the **Audit Policies** tab.

--- a/data-management-library/security/data-safe/workshop/view-registered-target-db/view-registered-target-db.md
+++ b/data-management-library/security/data-safe/workshop/view-registered-target-db/view-registered-target-db.md
@@ -13,7 +13,7 @@ To complete this lab, you need to have the following:
 - Oracle Data Safe enabled in a region of your tenancy
 - A registered target database in Oracle Data Safe
 
-## **STEP 1**: Sign in to Oracle Cloud Infrastructure
+## **PART 1**: Sign in to Oracle Cloud Infrastructure
 
 - From any browser, enter the following url:
 
@@ -32,7 +32,7 @@ To complete this lab, you need to have the following:
   ![](./images/oci-sign-in.png " ")
 
 
-## **STEP 2**: Sign in to the Oracle Data Safe Console
+## **PART 2**: Sign in to the Oracle Data Safe Console
 
 - From the navigation menu in Oracle Cloud Infrastructure, select **Data Safe**.
 
@@ -54,7 +54,7 @@ To complete this lab, you need to have the following:
 
 
 
-## **STEP 3**: View the Oracle Data Safe Dashboard
+## **PART 3**: View the Oracle Data Safe Dashboard
 
 - Notice that when you sign in to Oracle Data Safe, you are presented with a dashboard on the **Home** tab.
 
@@ -81,14 +81,14 @@ To complete this lab, you need to have the following:
 
 
 
-## **STEP 4**: View details for a registered target database in Oracle Data Safe
+## **PART 4**: View details for a registered target database in Oracle Data Safe
 
 - Click the **Targets** tab. Notice that there is only one target database to which you have access.
 
   An Oracle Data Safe administrator configured an authorization policy in Oracle Data Safe to grant you access to the resource group that contains your database.
 
     ![](./images/select-targets-tab.png " ")
- 
+
 
 - Click the name of your target database.
 

--- a/data-management-library/security/index.html
+++ b/data-management-library/security/index.html
@@ -33,7 +33,7 @@
         <nav class="hol-Nav">
             <button id="closeNav" class="hol-Nav-close" aria-label="Close Menu" title="Close Menu"><span
                     class="hol-Nav-closeIcon"></span></button>
-            <div class="hol-Nav-title">Lab Contents</div>
+            <div class="hol-Nav-title">Contents</div>
             <ul class="hol-Nav-list">
             </ul>
         </nav>

--- a/templates/redwood-hol/index.html
+++ b/templates/redwood-hol/index.html
@@ -33,7 +33,7 @@
         <nav class="hol-Nav">
             <button id="closeNav" class="hol-Nav-close" aria-label="Close Menu" title="Close Menu"><span
                     class="hol-Nav-closeIcon"></span></button>
-            <div class="hol-Nav-title">Lab Contents</div>
+            <div class="hol-Nav-title">Contents</div>
             <ul class="hol-Nav-list">
             </ul>
         </nav>

--- a/templates/redwood-hol/manifest.json
+++ b/templates/redwood-hol/manifest.json
@@ -1,11 +1,8 @@
 {
     "tutorials": [
-        {            
-            "title": "Enter tutorial title here",
-            "description": "This 15-minute tutorial walks you through the steps to...",
-            "partnumber": "E12345_01",
-            "publisheddate": "10/14/2019",
-            "contentid": "123456",
+        {
+            "title": "Enter lab title here",
+            "description": "This lab walks you through the steps to...",
             "filename": "content.md"
         }
     ]


### PR DESCRIPTION
Data Safe example: using PART 1 rather than STEP 1 for all Lab parts. This works better with the button "Expand all Parts".

Template: removed contentid, publishdate and partnumber from manifest.json.  Changed "Lab Contents" to just "Contents" in index.html file.