### PR TITLE
added link to bike_share_prediction.json in LabGuide500

### DIFF
--- a/workshops/bike-share-prediction/LabGuide500.md
+++ b/workshops/bike-share-prediction/LabGuide500.md
@@ -51,7 +51,7 @@ This lab walks you through the steps to create a linear regression model in the 
 
 -   In the **Notebooks** section, click on **Import** and import the [**Bike Share Availability Prediction.json**](./files/scripts/Bike Share Availability Prediction.json) file.
 
--   If you are on Orale/learning library, click on <a href="https://github.com/oracle/learning-library/blob/master/workshops/bike-share-prediction/files/scripts/Bike%20Share%20Availability%20Prediction.json" target="_blank">here</a> to download the file.
+-   If you are on Orale/learning library, click on <a href="https://raw.githubusercontent.com/oracle/learning-library/master/workshops/bike-share-prediction/files/scripts/Bike%20Share%20Availability%20Prediction.json" target="_blank">here</a> to download the file.
 
 ![](./images/500/Picture500-17.png)
 

--- a/workshops/bike-share-prediction/LabGuide500.md
+++ b/workshops/bike-share-prediction/LabGuide500.md
@@ -51,7 +51,7 @@ This lab walks you through the steps to create a linear regression model in the 
 
 -   In the **Notebooks** section, click on **Import** and import the [**Bike Share Availability Prediction.json**](./files/scripts/Bike Share Availability Prediction.json) file.
 
--   If you are on Orale/learning library, click on <a href="https://raw.githubusercontent.com/oracle/learning-library/master/workshops/bike-share-prediction/files/scripts/Bike%20Share%20Availability%20Prediction.json" target="_blank">here</a> to download the file.
+-   If you are on Orale/learning library, click on <a href="https://raw.githubusercontent.com/oracle/learning-library/master/workshops/bike-share-prediction/files/scripts/Bike%20Share%20Availability%20Prediction.json" target="_blank">here</a> to download the file (right click then save page as .json file). 
 
 ![](./images/500/Picture500-17.png)
 

--- a/workshops/bike-share-prediction/LabGuide500.md
+++ b/workshops/bike-share-prediction/LabGuide500.md
@@ -51,6 +51,8 @@ This lab walks you through the steps to create a linear regression model in the 
 
 -   In the **Notebooks** section, click on **Import** and import the [**Bike Share Availability Prediction.json**](./files/scripts/Bike Share Availability Prediction.json) file.
 
+-   If you are on Orale/learning library, click on <a href="https://github.com/oracle/learning-library/blob/master/workshops/bike-share-prediction/files/scripts/Bike%20Share%20Availability%20Prediction.json" target="_blank">here</a> to download the file.
+
 ![](./images/500/Picture500-17.png)
 
 The entire code for creating the model in OML is now accessible in the **Bike Share Availability Prediction** notebook.


### PR DESCRIPTION
Added link to bike_share_prediction.json in LabGuide500, users can now access file without exiting the lab.