### PR TITLE
In ADW loading lab, restore missing SQL script to define CHANNELS_LOC…

### DIFF
--- a/data-management-library/autonomous-database/shared/adb-loading/files/define_channels_local_table.txt
+++ b/data-management-library/autonomous-database/shared/adb-loading/files/define_channels_local_table.txt
@@ -1,0 +1,7 @@
+CREATE TABLE channels_local (
+    channel_id                  NUMBER(6)          NOT NULL,
+    channel_desc                VARCHAR2(20)    NOT NULL,
+    channel_class               VARCHAR2(20)    NOT NULL,
+    channel_class_id            NUMBER(6)          NOT NULL,
+    channel_total               VARCHAR2(13)    NOT NULL,
+    channel_total_id            NUMBER(6)          NOT NULL);


### PR DESCRIPTION
…AL table

The define_channels_local_table.txt file was missing from the FILES folder of the data loading lab. Added it back in.