### PR TITLE
Updated part of a lab for new OCI UI, fixed typos

### DIFF
--- a/oci-library/L100-LAB/Block_Volume/Block_Volume_HOL.md
+++ b/oci-library/L100-LAB/Block_Volume/Block_Volume_HOL.md
@@ -73,7 +73,7 @@ A common usage of Block Volume is adding storage capacity to an Oracle Cloud Inf
    - **Attachement mode:** iSCSI
    - **Block Volume:** Select the volume created
    - **Device Path:** Select `/dev/oracleoci/oraclevdb`
-   - Cick **Attach**
+   - Click **Attach**
  
    ![](media/Attached2.png)
 

--- a/oci-library/L100-LAB/Using_Reserved_Public_IP/Reserved_Public_IP_HOL.md
+++ b/oci-library/L100-LAB/Using_Reserved_Public_IP/Reserved_Public_IP_HOL.md
@@ -4,6 +4,12 @@
 
 [Overview](#overview)
 
+[Pre-Requisites](#pre-requisites)# ReservedIP Practice - Using Reserved Public IP 
+  
+## Table of Contents
+
+[Overview](#overview)
+
 [Pre-Requisites](#pre-requisites)
 
 [Practice 1: Sign in to OCI Console and create reserved public IP](#practice-1-sign-in-to-oci-console-and-create-reserved-public-ip)
@@ -59,6 +65,8 @@ Certain types of resources in your tenancy are designed to be directly reachable
 - Click **Create Virtual Cloud Network**
 
 - Click **Close**
+
+**NOTE:** The option to "Create Virtual Cloud Network Plus Related Resources" may not be a selectable option in more recent versions of the UI. If this option is not available, create a subnet with parameters as specified in the picture below after you create this VCN. You will need the subnet when creating the Compute instance.
 
 ![]( img/RESERVEDIP_HOL003.PNG)
 ![]( img/RESERVEDIP_HOL004.PNG)

--- a/oci-library/L100-LAB/VCN/VCN_HOL.md
+++ b/oci-library/L100-LAB/VCN/VCN_HOL.md
@@ -3,8 +3,11 @@
 ## Table of Contents
 
 [Overview](#overview)
+
 [Pre-Requisites](#pre-requisites)
+
 [Create Your VCN](#create-your-vcn)
+
 [Summary](#summary)
 
 **Note:** *Some of the UIs might look a little different than the screen shots included in the instructions, but you can still use the instructions to complete the hands-on labs.*


### PR DESCRIPTION
- In L100 Reserved Public IP lab, added a note explaining that the subnet has to be created in a separate step since the OCI UI change. Indicated that a subnet can be made using parameters in the screenshot already present

- In L100 Block Volume lab, fixed typo "Cick" to "Click"

- In L100 VCN lab, fixed spacing of table of contents so that the section headings appear on different lines, as in the other labs.