### PR TITLE
Move embedded video on SQL Developer from ADW Lab 3 to Lab 7

### DIFF
--- a/data-management-library/autonomous-database/shared/adb-sqldevweb/adb-sqldevweb.md
+++ b/data-management-library/autonomous-database/shared/adb-sqldevweb/adb-sqldevweb.md
@@ -14,10 +14,6 @@ You will run a basic query on the SSB data set which is a 1TB data set with one 
 
 *Note: While this lab uses ADW, the steps are identical for creating and connecting to an ATP database.*
 
-Watch a video demonstration of connecting to your new Autonomous Database instance using SQL Developer.
-
-[](youtube:PHQqbUX4T50)
-
 ### Objectives
 
 - Learn how to connect to your new Autonomous Database using SQL Developer Web

--- a/data-management-library/autonomous-database/shared/adw-connection-wallet/adw-connection-wallet.md
+++ b/data-management-library/autonomous-database/shared/adw-connection-wallet/adw-connection-wallet.md
@@ -6,7 +6,9 @@ This lab walks you through the steps to download and configure a connection wall
 
 **Note:** While this lab uses ADW, the steps are identical for connecting to an autonomous database in ATP.
 
-Click [here](https://www.youtube.com/watch?v=PHQqbUX4T50&autoplay=0&html5=1) to watch a video demonstration of connecting to an Autonomous Data Warehouse database using SQL Developer.
+Watch a video demonstration of connecting to an autonomous database instance using SQL Developer.
+
+[](youtube:PHQqbUX4T50)
 
 ### Objectives
 


### PR DESCRIPTION
Per Nilay, since Lab 3 now uses SQL Developer **Web** instead of SQL Developer, there's no need for a video on SQL Developer in this lab. Removed the video from Lab 3.
Lab 7, which downloads a wallet and uses SQL Developer, had a **NON-EMBEDDED** link to this video, causing a new browser tab to open in YouTube. Changed this link to show the video embedded in Lab 7, so viewer can watch without being transported out of the lab.