### PR TITLE
Fix redundant `bash` words in the snippets

### DIFF
--- a/developer-library/micronaut-oci-atp/deploy/deploy.md
+++ b/developer-library/micronaut-oci-atp/deploy/deploy.md
@@ -20,8 +20,7 @@ In this lab you will:
 
 1. Before deploying, ensure the wallet exists on the VM by running the snippet produced by `setup.sh` that looks similar to:
 
-    ```
-    bash
+    ```bash
     # run on local machine to push to VM
     <copy>
     scp -i ~/.ssh/id_oci -r /tmp/wallet opc@[VM IP Address]:/tmp/wallet
@@ -30,8 +29,7 @@ In this lab you will:
 
 2. Build JAR with:
 
-    ```
-    bash
+    ```bash
     # run on local machine
     <copy>
     ./gradlew assemble
@@ -40,8 +38,7 @@ In this lab you will:
 
 3. Push JAR to VM with the snippet produced by *setup.sh* that looks similar to this:
 
-    ```
-    bash
+    ```bash
     # run on local machine to push to VM
     <copy>
     scp -i ~/.ssh/id_oci -r build/libs/example-atp-0.1-all.jar opc@[VM IP Address]:/app/application.jar
@@ -50,8 +47,7 @@ In this lab you will:
 
 4. Push Helidon native image to the VM:
 
-    ```
-    bash
+    ```bash
     # run on local machine to push to VM, from the directory that contains downloaded native image
     <copy>
     scp -i ~/.ssh/id_oci ./helidon-mp-service opc@[VM IP Address]:/app/helidon-mp-service
@@ -60,8 +56,7 @@ In this lab you will:
 
 5. Run the Helidon application on the VM:
 
-    ```
-    bash
+    ```bash
     # run on VM to start Helidon application
     <copy>
     ./app/helidon-mp-service
@@ -72,7 +67,6 @@ In this lab you will:
 
     ```
     <copy>
-    bash
     # run on VM to start Micronaut application
     export MICRONAUT_OCI_DEMO_PASSWORD=[Your atp_wallet_password]
     export TNS_ADMIN=/tmp/wallet

--- a/developer-library/micronaut-oci-atp/setup/setup.md
+++ b/developer-library/micronaut-oci-atp/setup/setup.md
@@ -26,7 +26,6 @@ In this lab you will:
 
     ```
     <copy>
-    bash
     wget -O setup.sh https://objectstorage.us-phoenix-1.oraclecloud.com/n/toddrsharp/b/micronaut-lab-assets/o/setup.sh
     chmod +x setup.sh
     ./setup.sh
@@ -68,7 +67,6 @@ To connect locally you need download and configure the ATP Wallet locally.
 
     ```
     <copy>
-    bash
     unzip /path/to/Wallet_mnociatp.zip -d /tmp/wallet
     </copy>
     ```
@@ -84,7 +82,6 @@ To connect locally you need download and configure the ATP Wallet locally.
 
     ```
     <copy>
-    bash
     mn create-app example-atp --features oracle,data-jdbc
     cd example-atp
     </copy>
@@ -94,8 +91,7 @@ Note: By default Micronaut will use the [Gradle](https://gradle.org/) build tool
 
 2. If you do not have the Micronaut CLI installed and are running on Linux or OS X you can alternatively `curl` and `unzip`:
 
-    ```
-    bash
+    ```bash
     curl https://launch.micronaut.io/example-atp.zip\?features\=oracle,data-jdbc -o example-atp.zip
     unzip example-atp.zip -d example-atp
     cd example-atp


### PR DESCRIPTION
Fix redundant `bash` words in the snippets see #1824

![image](https://user-images.githubusercontent.com/1773630/91956529-0ef86280-ed05-11ea-9540-0fc31be6a42d.png)


Signed-off-by: Daniel Kec <daniel.kec@oracle.com>