### PR TITLE
changed title "Oracle Database Quickstart' Workshop to "Get Started w…

### DIFF
--- a/data-management-library/database/db-quickstart/db-quickstart-workshop/manifest.json
+++ b/data-management-library/database/db-quickstart/db-quickstart-workshop/manifest.json
@@ -1,11 +1,11 @@
 {
-    "workshoptitle": "Oracle Database Quickstart",    
+    "workshoptitle": "Get Started with Oracle Database",    
     "tutorials": [
         {
             "title": "Prerequisites",
             "description": "Get a Free Trial",
             "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
-        },        
+        },
         {
           "title": "Introduction",
           "description": "Introduction",

--- a/data-management-library/database/db-quickstart/workshops/livelabs/manifest.json
+++ b/data-management-library/database/db-quickstart/workshops/livelabs/manifest.json
@@ -1,5 +1,5 @@
 {
-    "workshoptitle": "Oracle Database Quickstart",
+    "workshoptitle": "Get Started with Oracle Database",
     "tutorials": [
         {
             "title": "Prerequisites",


### PR DESCRIPTION
…ith Oracle Database"

This workshop introducing Oracle Database was too similar to the title of our "Autonomous Database Quickstart" workshop; PMs pointed to it by accident. So changing title of "Oracle Database Quickstart' Workshop to "Get Started with Oracle Database".