### PR TITLE
Fix pointer to wrong screenshot in Get Started with Oracle Database W…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ GitHub Oracle Learning Library Clone - Shortcut.lnk
 data-management-library/autonomous-database/autonomous-data-warehouse_PRIOR TO SQLDEV WEB STREAMLINING.zip
 .idea/ 
 *.iml
+data-management-library/autonomous-database/shared/adb-auto-scaling/images/send to Nilay.png

--- a/data-management-library/database/db-quickstart/db-create-schema/db-create-schema.md
+++ b/data-management-library/database/db-quickstart/db-create-schema/db-create-schema.md
@@ -302,7 +302,7 @@ In this section, you execute the `REVOKE` statement to revoke user and role syst
 
     `REVOKE CREATE SESSION FROM online_shoppe;`
 
-  ![](./images/revoke-connect.png " ")
+  ![](./images/revoke-create-session.png " ")
 
 2. Attempt to sign back in to SQL Developer Web as the **online_shoppe** user, by pasting into your browser the URL containing the alias that you used back in **Step 4: Log in to SQL Developer Web as the Database User and Create Tables**.
 


### PR DESCRIPTION
…orkshop

In Lab 5, Step 8: markdown text had been fixed, but markdown pointer to screenshot needed to be changed from 
/database/db-quickstart/db-create-schema/images/revoke-connect.png 
to 
/database/db-quickstart/db-create-schema/images/revoke-create-session.png