### PR TITLE
for "Get Started with Oracle Database" ID 3280, fixed manifest.json p…

### DIFF
--- a/data-management-library/database/db-quickstart/workshops/freetier/manifest.json
+++ b/data-management-library/database/db-quickstart/workshops/freetier/manifest.json
@@ -6,7 +6,7 @@
         {
             "title": "Introduction",
             "description": "Introduction",
-            "filename": "./../intro.md"
+            "filename": "../../db-quickstart-workshop/intro.md"
         },
         {
             "title": "Getting Started",


### PR DESCRIPTION
…ath to intro.md

After re-organizing the workshop's folders to move manifest.json and index.html from the db-quickstart-workshop folder into the \workshops\freetier and \workshops\livelabs folders, we fixed the livelabs manifest.json to point to "filename": "../../db-quickstart-workshop/intro.md", but forgot to fix the freetier manifest.json to point to the same path. Just changed the freetier manifest.json to point to "filename": "../../db-quickstart-workshop/intro.md", instead of "filename": "./../intro.md"