### PR TITLE
Update 7-labs-create-custom-image-for-marketplace.md [Internal]

### DIFF
--- a/sample-livelabs-templates/create-labs/labs/7-labs-create-custom-image-for-marketplace/7-labs-create-custom-image-for-marketplace.md
+++ b/sample-livelabs-templates/create-labs/labs/7-labs-create-custom-image-for-marketplace/7-labs-create-custom-image-for-marketplace.md
@@ -59,7 +59,9 @@ This lab assumes you have:
     hostnamectl set-hostname <host>.livelabs.oraclevcn.com
 
     # Add static name to /etc/hosts
-    echo "\$(oci-metadata -g privateIp --value-only | head -1)   <host>.livelabs.oraclevcn.com  <host>" >>/etc/hosts
+    #echo "\$(oci-metadata -g privateIp --value-only | head -1)   <host>.livelabs.oraclevcn.com  <host>" >>/etc/hosts
+    echo "\$(oci-metadata -g privateIp |sed -n -e 's/^.*Private IP address: //p')   <host>.livelabs.oraclevcn.com  <host>" >>/etc/hosts
+
     EOF
     </copy>
     ```


### PR DESCRIPTION
Workround for oci-utils where "oci-metadata -g privateIP --value-only" is returing "None" rather than the expected IP address