### PR TITLE
Pull request for #3380 - Removed references to "lab" for OHC Learn compatibility

### DIFF
--- a/developer-library/weblogic-to-oci/gather-db-info/gather-db-info.md
+++ b/developer-library/weblogic-to-oci/gather-db-info/gather-db-info.md
@@ -2,13 +2,11 @@
 
 ## Introduction
 
-This lab with guide you through getting useful information regarding a database provisioned on Oracle Cloud Infrastructure (OCI).
+We will guide you through getting useful information regarding a database provisioned on Oracle Cloud Infrastructure (OCI).
 
-Estimated Lab Time: 5 minutes.
+Estimated Completion Time: 5 minutes.
 
 ### Objectives
-
-In this lab you will:
 
 - Gather the database node IP.
 - Gather the database connection string.

--- a/developer-library/weblogic-to-oci/intro-oke/intro-oke.md
+++ b/developer-library/weblogic-to-oci/intro-oke/intro-oke.md
@@ -2,18 +2,17 @@
 
 ## About this workshop
 
-This lab will walk you through the process of migrating an existing on-premises WebLogic domain to WebLogic for Oracle Kubernetes Engine (OKE). The WebLogic domain we'll migrate contains Java applications and a datasource connecting to a database that will be migrated along with the WebLogic domain.
+We will walk you through the process of migrating an existing on-premises WebLogic domain to WebLogic for Oracle Kubernetes Engine (OKE). The WebLogic domain we'll migrate contains Java applications and a datasource connecting to a database that will be migrated along with the WebLogic domain.
 
 Attached below is a sample architecture of the final solution:
 ![](./images/arch-oke.png " ")
 
-Estimated Lab Time: 80 to 120 minutes depending on the path chosen.
+Estimated Completion Time: 80 to 120 minutes depending on the path chosen.
 
 ### Objectives
 
 *Perform the end-to-end migration of a local WebLogic domain to Oracle Kubernetes Engine (OKE), provisioning WebLogic on OKE with the marketplace.*
 
-In this lab, you will:
 - Provision a demo environment to use as the on-premises environment to be migrated.
 - Prepare the OCI tenancy to provision WebLogic Server from the marketplace.
 - Provision a new empty WebLogic domain on OKE with the marketplace.
@@ -49,7 +48,7 @@ Allow group MyGroup to manage all-resources in compartment MyCompartment
 </copy>
 ```
 
-> **Important:** This lab uses the WebLogic version 12.2.1.4 stack with a non-JRF domain. It is similar with version 12.2.1.3; however, WebLogic version 10.3.6 requires a JRF domain by default, which requires a database as a backend. The *only* database versions compatible with WebLogic 10.3.6 on OCI are database version 11.2.0.4 and 12.1.0.2. Note that database 11.2.0.4 requires the Oracle Grid Infrastructure when provisioning, or it will not be visible as an option when selecting the database image version.
+> **Important:** This workshop uses the WebLogic version 12.2.1.4 stack with a non-JRF domain. It is similar with version 12.2.1.3; however, WebLogic version 10.3.6 requires a JRF domain by default, which requires a database as a backend. The *only* database versions compatible with WebLogic 10.3.6 on OCI are database version 11.2.0.4 and 12.1.0.2. Note that database 11.2.0.4 requires the Oracle Grid Infrastructure when provisioning, or it will not be visible as an option when selecting the database image version.
 
 
 ## Acknowledgements

--- a/developer-library/weblogic-to-oci/migrate-app-db-datapump-oke/migrate-app-db-datapump-oke.md
+++ b/developer-library/weblogic-to-oci/migrate-app-db-datapump-oke/migrate-app-db-datapump-oke.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-This lab walks you through the steps to migrate the on-premises application database to the database provisioned on Oracle Cloud Infrastructure (OCI) using DataPump.
+We will walk you through the steps to migrate the on-premises application database to the database provisioned on Oracle Cloud Infrastructure (OCI) using DataPump.
 
-Estimated Lab Time: 10 minutes.
+Estimated Completion Time: 10 minutes.
 
 ### About Product/Technology
 
@@ -12,20 +12,16 @@ Estimated Lab Time: 10 minutes.
 - DataPump export function creates a DDL + data dump of the user schema.
 - DataPump import function imports the data into the database.
 
-In this workshop we will be using wrapper scripts to export, move the data to the destination and import to complete a full migration.
+We will be using wrapper scripts to export, move the data to the destination, and import to complete a full migration.
 
 ### Objectives
 
-In this lab you will:
-
 - Get shell access to the on-premises database.
 - Use a DataPump script to export the database schema to migrate.
-- Edit the DataPump import script with the information collected in the database provisioning lab.
+- Edit the DataPump import script with the information collected during the database provisioning stage.
 - Run a DataPump import script to migrate the database schema to OCI.
 
 ### Prerequisites
-
-To run this lab you need:
 
 - To have provisioned the on-premises demo environment that includes the source database to migrate.
 - To have provisioned the target database on OCI.
@@ -138,9 +134,9 @@ First, we'll need to edit the `datapump_import.sh` script to target the OCI data
 
    ![](./images/provision-db-26-nodeip.png " ")
 
-4. Enter the `TARGET_DB_DOMAIN` name, from the database connection string.
+4. Enter the `TARGET_DB_DOMAIN` name from the database connection string.
 
-   If you followed the name convention defaults in the lab, it should be `nonjrfdbsubnet.nonjrfvcn.oraclevcn.com`.
+   If you followed the default naming conventions, it should be `nonjrfdbsubnet.nonjrfvcn.oraclevcn.com`.
 
    ![](./images/provision-db-27-connection2.png " ")
 

--- a/developer-library/weblogic-to-oci/on-prems-env-docker/on-prems-env-docker.md
+++ b/developer-library/weblogic-to-oci/on-prems-env-docker/on-prems-env-docker.md
@@ -2,15 +2,13 @@
 
 ## Introduction
 
-This lab will walk you through setting up a local environment to simulate an established on-premises environment, using Docker on your local machine.
+We will walk you through setting up a local environment to simulate an established on-premises environment, using Docker on your local machine.
 
-At the end of this lab, you will have a local environment running with an Oracle 12c database and WebLogic Server 12c with a domain containing two applications and a datasource.
+On completion, you will have a local environment running with an Oracle 12c database and WebLogic Server 12c with a domain containing two applications and a datasource.
 
-Estimated Lab Time: 30 minutes.
+Estimated Completion Time: 30 minutes.
 
 ### Objectives
-
-In this lab you will:
 
 - Get the Docker environment files.
 - Start up the Docker-based on-premises demo environment.
@@ -19,8 +17,6 @@ In this lab you will:
 
 
 ### Prerequisites
-
-To run this lab, you will need:
 
 - Docker installed locally to run the on-premises environment.
 

--- a/developer-library/weblogic-to-oci/on-prems-env-mp/on-prems-env-mp.md
+++ b/developer-library/weblogic-to-oci/on-prems-env-mp/on-prems-env-mp.md
@@ -2,15 +2,13 @@
 
 ## Introduction
 
-This lab walks you through setting up an environment to simulate an established on-premises environment, using a Compute instance on OCI deployed through the marketplace.
+We will walk you through setting up an environment to simulate an established on-premises environment, using a Compute instance on OCI deployed through the marketplace.
 
-At the end of this lab, you will have a simulated on-premises environment running with an Oracle 12c database and WebLogic Server 12c with a domain containing 2 applications and a datasource.
+On completion, you will have a simulated on-premises environment running with an Oracle 12c database and WebLogic Server 12c with a domain containing 2 applications and a datasource.
 
-Estimated Lab Time: 15 minutes.
+Estimated Completion Time: 15 minutes.
 
 ### Objectives
-
-In this lab you will:
 
 - Launch a demo marketplace image.
 - Check that the services are up and running.
@@ -18,8 +16,6 @@ In this lab you will:
 - Create a SSH key pair.
 
 ### Prerequisites
-
-For this lab you need:
 
 - A compute instance with 4 OCPUs available to run the image.
 

--- a/developer-library/weblogic-to-oci/on-prems-env/on-prems-env.md
+++ b/developer-library/weblogic-to-oci/on-prems-env/on-prems-env.md
@@ -13,7 +13,7 @@ Both paths provide a pre-packaged on-premises simulated environment, which inclu
 
 The marketplace image deployment is simpler and faster, while the Docker environment provides a way to more realistically simulate an on-premises environment as it runs on your local machine.
 
-Estimated Lab Time: 15 to 30 minutes depending on path chosen.
+Estimated Completion Time: 15 to 30 minutes depending on path chosen.
 
 ### Objectives
 

--- a/developer-library/weblogic-to-oci/prepare-oke/prepare-oke.md
+++ b/developer-library/weblogic-to-oci/prepare-oke/prepare-oke.md
@@ -2,13 +2,11 @@
 
 ## Introduction
 
-In this lab we will prepare the OCI environment to provision WebLogic Server for Oracle Cloud Infrastructure (OCI) from the Oracle Cloud Marketplace.
+We will prepare the OCI environment to provision WebLogic Server for Oracle Cloud Infrastructure (OCI) from the Oracle Cloud Marketplace.
 
-Estimated Lab Time: 5 minutes.
+Estimated Completiong Time: 5 minutes.
 
 ### Objectives
-
-In this lab you will:
 
 - Create a Vault.
 - Create a Key.
@@ -17,8 +15,6 @@ In this lab you will:
 - Copy the Secret OCIDs to use during the provisioning stage.
 
 ### Prerequisites
-
-For this lab you will need:
 
 - An OCI account with a compartment created.
 

--- a/developer-library/weblogic-to-oci/provision-app-db-oke/provision-app-db-oke.md
+++ b/developer-library/weblogic-to-oci/provision-app-db-oke/provision-app-db-oke.md
@@ -2,13 +2,11 @@
 
 ## Introduction
 
-This lab with guide you through provisioning an application database.
+We will guide you through provisioning an application database.
 
-Estimated Lab Time: 30 to 35 minutes including 25 to 30 minutes for provisioning time.
+Estimated Completion Time: 30 to 35 minutes including 25 to 30 minutes for provisioning time.
 
 ### Objectives
-
-In this lab you will:
 
 - Create a security list with proper ports open.
 - Create a private subnet for the application database.
@@ -175,7 +173,7 @@ In this section we will create a security list for the WebLogic subnet to be abl
 
   ![](./images/provision-db-25.png " ")
 
-To save some time, you can proceed to starting the database migration lab while the database is provisioning if you wish, however you will need the database fully provisioned and you will need to gather the database information before you can finish the migration.
+To save some time, you can start the database migration while the database is provisioning if you wish, however, you will need the database to be fully provisioned and you will need to gather the database information before you can finish the migration.
 
 
 ## Acknowledgements

--- a/developer-library/weblogic-to-oci/provision-wls-oke/provision-wls-oke.md
+++ b/developer-library/weblogic-to-oci/provision-wls-oke/provision-wls-oke.md
@@ -2,20 +2,18 @@
 
 ## Introduction
 
-This lab walks you through provisioning the WebLogic Infrastructure on Oracle Kubernetes Engine (OKE) by leveraging the OCI Cloud Marketplace.
+We will walk you through provisioning the WebLogic Infrastructure on Oracle Kubernetes Engine (OKE) by leveraging the OCI Cloud Marketplace.
 
-Estimated Lab Time: 30 minutes.
+Estimated Completiong Time: 30 minutes.
 
 ### Objectives
-
-In this lab you will:
 
 - Provision WebLogic Server on OKE e via the Oracle Cloud Marketplace offering.
 - Gather information for further steps.
 
 ### Prerequisites
 
-For this lab, you need to have prepared the Oracle Cloud Infrastructure (OCI) tenancy with:
+You need to have prepared the Oracle Cloud Infrastructure (OCI) tenancy with:
 
 - A Vault.
 - A Key.
@@ -29,7 +27,7 @@ For this lab, you need to have prepared the Oracle Cloud Infrastructure (OCI) te
 
   ![](./images/provision-1.png " ")
 
-2. In the search input, type `weblogic`. For this lab, we'll use the **WebLogic Enterprise Edition on OKE UCM**.
+2. In the search input, type `weblogic` and click **WebLogic Enterprise Edition on OKE UCM**.
 
    ![](./images/provision-2.png " ")
 

--- a/developer-library/weblogic-to-oci/tear-down-dbcs/tear-down-dbcs.md
+++ b/developer-library/weblogic-to-oci/tear-down-dbcs/tear-down-dbcs.md
@@ -4,19 +4,19 @@
 
 Congratulations! You've come so far and completed the workshop, and you might wonder how to clean up resources.
 
-Estimated Lab Time: 15 minutes
+Estimated Completion Time: 15 minutes
 
 *You should not keep the instances deployed on OCI as part of this workshop running once your are done, or use in any way for actual workloads: since the DB and WebLogic credentials are publically available it would be a security issue.*
 
 ### Objectives
 
-In this lab you will tear down the infrastructure provisioned.
+- Tear down the infrastructure provisioned.
 
 ## **STEP 1:** Cleaning up the on-premises environment
 
 ### If you used docker
 
-1. stop the services and remove containers:
+1. Stop the services and remove containers:
 
     ```
     <copy>


### PR DESCRIPTION
On OHC, the term "lab" refers to Luna lab rather than LiveLabs

@streamnsight: These are the last round of edits from me for OHC Learn. Changes can be previewed here, thanks!
https://coltse.github.io/learning-library/developer-library/weblogic-to-oci/workshops/weblogic-on-oke/freetier/