### PR TITLE
Workshop ID#6161 added the missing Getting Started to manifest, and 3…

### DIFF
--- a/data-management-library/autonomous-database/shared/adb-analytics-using-sql/deeper-analysis-movie-sales-data/deeper-analysis-movie-sales-data.md
+++ b/data-management-library/autonomous-database/shared/adb-analytics-using-sql/deeper-analysis-movie-sales-data/deeper-analysis-movie-sales-data.md
@@ -31,7 +31,7 @@ Estimated Lab Time: 20 minutes
 
  **NOTE:** Different regions organize their day numbers in different ways. In Germany, for example, the week starts on Monday, so that day is assigned as day number one. In the United States, the day numbers start at one on Sunday. Therefore, it’s important to understand these regional differences. Oracle Database provides session settings that allow you to control these types of regional differences by using the **`ALTER SESSION SET`** command.
 
-1. Before we being creating our next SQL, let’s set our territory as being “America” by using the following command:
+1. Before we begin creating our next SQL, let’s set our territory as being “America” by using the following command:
 
     ```
     <copy>ALTER SESSION SET NLS_TERRITORY = America;</copy>

--- a/data-management-library/autonomous-database/shared/adb-analytics-using-sql/freetier/manifest.json
+++ b/data-management-library/autonomous-database/shared/adb-analytics-using-sql/freetier/manifest.json
@@ -8,6 +8,11 @@
         "filename": "../workshop-intro/workshop-intro.md"
       },
       {
+            "title": "Getting Started",
+            "description": "Get a Free Trial",
+            "filename": "https://raw.githubusercontent.com/oracle/learning-library/master/common/labs/cloud-login/pre-register-free-tier-account.md"
+      },
+      {
         "title": "Lab 1: Analyzing Movie Sales Data",
         "description": "Analyzing Movie Sales Data",
         "filename": "../analyzing-movie-sales-data/analyzing-movie-sales-data.md"

--- a/data-management-library/autonomous-database/shared/adb-analytics-using-sql/targeting-customers/targeting-customers.md
+++ b/data-management-library/autonomous-database/shared/adb-analytics-using-sql/targeting-customers/targeting-customers.md
@@ -44,7 +44,7 @@ This all sounds very complicated, but using SQL pattern matching, it is very eas
 We can find the customers who watched at least 1 family genre movie during a quarter by using the SQL pattern matching function **`MATCH_RECOGNIZE`**. To map this pattern within our query, we use the following to outline what we are looking for:
 
 ```
-PATTERN (family+)</pre>
+PATTERN (family+)
 ```
 And then the pattern ID defined as follows:
 ```

--- a/data-management-library/autonomous-database/shared/adb-analytics-using-sql/workshop-intro/workshop-intro.md
+++ b/data-management-library/autonomous-database/shared/adb-analytics-using-sql/workshop-intro/workshop-intro.md
@@ -11,7 +11,7 @@ Estimated Workshop Duration: 1 hour, 30 minutes
 
 Everyone can benefit from doing the lab exercises in this workshop: database technical experts, LOB Developers, LOB analysts, data warehouse architects to database administrators, business users who want to focus on extracting meaning and insight from their own data, along with data scientists who want to build machine learning models within the context of a data warehouse project.
 
-### Objectives 
+### Objectives
 
 The aim of this lab is to introduce you to the overall workshop objectives and the movie streaming business scenario used in this workshop where you will take on a roll within a company called Oracle MovieStream. At the end of this specific lab, you will have learned how to do the following:
 
@@ -27,7 +27,7 @@ Before you launch into this workshop, you will need the following:
 
 2. Basic level of understanding of SQL query language
 
-3. ***You will need to have completed the related LiveLabs workshop***, **Autonomous Data Warehouse: Data Loading and Management Using SQL on the MovieStream Dataset**. The **Getting Started** section of that prerequisite workshop describes how to obtain an Oracle cloud account if you do not already have one. In that workshop you provision an Oracle Autonomous Database, and then load the MovieStream data needed for this analytics workshop.
+3. ***You will need to have completed the related LiveLabs workshop***, [**ADW: Data Loading and Management Using SQL on the MovieStream Dataset**](https://apexapps.oracle.com/pls/apex/dbpm/r/livelabs/view-workshop?wid=838&clear=180&session=102687399911158). The **Getting Started** section of that prerequisite workshop describes how to obtain an Oracle cloud account if you do not already have one. In that workshop you provision an Oracle Autonomous Database, and then load the MovieStream data needed for this analytics workshop.
 
 **Note:** The timings and screenshots in this workshop are based on using 8 OCPUs. If you obtain a 30-day trial license and opt to configure fewer OCPUs or opt for an “Always Free” instance with one OCPU, the response times and query times will be different to those shown in the various screenshots.
 


### PR DESCRIPTION
… minor typos

Workshop ID#6161 "ADW: Analytics Using SQL on the MovieStream Data Set" added the missing "Getting Started" section to the manifest.json file, and made 3 minor typo corrections to this workshop's labs:
"Introduction": I added hyperlink to the prereq Data Loading workshop
"Lab 3: Deeper Analysis Of Movie Sales Data": I corrected the spelling of "begin"
"Lab 6: Targeting Customers Based On Viewing Patterns":  I removed the tag </pre> from a code snippet