### PR TITLE
Workshop ID #141 Fix a code snippet in data loading lab and change "S…

### DIFF
--- a/data-management-library/autonomous-database/shared/adb-auto-scaling/adb-auto-scaling.md
+++ b/data-management-library/autonomous-database/shared/adb-auto-scaling/adb-auto-scaling.md
@@ -38,7 +38,7 @@ The **business case** we want to answer here is to **summarize orders by month a
 - **Test 2**: You will enable auto scaling and again have 3 SQL Developer Web sessions executing queries. Auto scaling will allow your running sessions to use up to 3x more OCPUs, reducing your execution times significantly.
 
 ## **Test 1 - Auto Scaling Disabled**
-In steps 1 through 3, with auto scaling **disabled**, you will have 3 SQL Developer Web sessions executing queries sharing the CPU and IO resources, and you will examine query times.
+In tasks 1 through 3, with auto scaling **disabled**, you will have 3 SQL Developer Web sessions executing queries sharing the CPU and IO resources, and you will examine query times.
 
 ## Task 1: Disable Auto Scaling and Create Four Connections in SQL Developer Web to your ADW Database
 
@@ -55,8 +55,8 @@ In steps 1 through 3, with auto scaling **disabled**, you will have 3 SQL Develo
     ![](./images/click-sql.png)
 
 3. Create and save 4 SQL Developer Web worksheets. In SQL Developer Web worksheets, you choose the consumer group from the drop-down menu in the upper-right corner.:
-    - Save the first worksheet with the name **Setup**. You will use this worksheet with the LOW consumer group in STEP 2, to run the setup that creates a procedure for running test queries. The LOW consumer group is appropriate for non-CPU-intensive tasks such as this creation of a procedure.
-    - Save the other 3 worksheets with the names **Query 1**, **Query 2**, and **Query 3**. In later steps, you will use these 3 worksheets to simultaneously run the test queries using the HIGH consumer group. For real production workloads, you will typically use the MEDIUM or HIGH consumer groups, since they have higher parallelism and lower concurrency. A worksheet using the HIGH consumer group gets top priority. You may read [more about consumer groups here](https://docs.oracle.com/en/cloud/paas/autonomous-data-warehouse-cloud/user/manage-priorities.html#GUID-80E464A7-8ED4-45BB-A7D6-E201DD4107B7).
+    - Save the first worksheet with the name **Setup**. You will use this worksheet with the LOW consumer group in Task 2, to run the setup that creates a procedure for running test queries. The LOW consumer group is appropriate for non-CPU-intensive tasks such as this creation of a procedure.
+    - Save the other 3 worksheets with the names **Query 1**, **Query 2**, and **Query 3**. In later tasks, you will use these 3 worksheets to simultaneously run the test queries using the HIGH consumer group. For real production workloads, you will typically use the MEDIUM or HIGH consumer groups, since they have higher parallelism and lower concurrency. A worksheet using the HIGH consumer group gets top priority. You may read [more about consumer groups here](https://docs.oracle.com/en/cloud/paas/autonomous-data-warehouse-cloud/user/manage-priorities.html#GUID-80E464A7-8ED4-45BB-A7D6-E201DD4107B7).
 
   ![](./images/save-worksheets.png " ")
 
@@ -65,7 +65,7 @@ In steps 1 through 3, with auto scaling **disabled**, you will have 3 SQL Develo
   ![](./images/create-four-worksheets.png " ")
 
 ## Task 2: Create the `test_proc` Procedure to Generate the Test Workload
-In this step, you run a script that will:
+In this task, you run a script that will:
 - Create the procedure **test\_proc** for the workload used in the test.
     - When this procedure is executed, it will run a query in a loop 2 times, to answer the business case from our [SSB database](https://docs.oracle.com/en/cloud/paas/autonomous-data-warehouse-cloud/user/autonomous-sample-data.html#GUID-4BB2B49B-0C20-4E38-BCC7-A61D3F45390B): Aggregate orders by month and city, for customers in the US, in the Fall of 1992.
     - After performing this lab, you may go back and increase the `i_executions` number for further testing.)
@@ -231,10 +231,10 @@ In this step, you run a script that will:
 
     ![](./images/test-one-results.png " ")
 
-  In the next steps, let's see if auto scaling reduces query time and increases CPU and IO usage.
+  In the next tasks, let's see if auto scaling reduces query time and increases CPU and IO usage.
 
 ## **Test 2 - Auto Scaling Enabled, Providing 3x the Amount of CPU and IO Resources**
-In steps 4 through 6, you will enable auto scaling and again have 3 SQL Developer Web sessions executing queries. Auto scaling will allow your running sessions to use up to 3x more OCPUs, reducing your execution times significantly.
+In tasks 4 through 6, you will enable auto scaling and again have 3 SQL Developer Web sessions executing queries. Auto scaling will allow your running sessions to use up to 3x more OCPUs, reducing your execution times significantly.
 
 ## Task 4: Enable Auto Scaling
 

--- a/data-management-library/autonomous-database/shared/adb-event-alarm/adb-event-alarm.md
+++ b/data-management-library/autonomous-database/shared/adb-event-alarm/adb-event-alarm.md
@@ -34,7 +34,7 @@ OCI Notifications service enables you to set up communication channels for publ
 
 **Message**: The content that is published to a topic. Each message is delivered at least once per subscription.
 
-In Steps 1 through 7, you create a notification topic with an email subscription, then create a rule that triggers a message (email) when a database is stopped.
+In Tasks 1 through 7, you create a notification topic with an email subscription, then create a rule that triggers a message (email) when a database is stopped.
 
 ## Task 1: Sign in to OCI Console and Create a Notification Topic
 
@@ -53,7 +53,7 @@ In Steps 1 through 7, you create a notification topic with an email subscription
 
 ## Task 2: Create a Subscription to the Topic
 
-Now that you have created a notification topic, create a subscription to that topic, so that you can receive email alerts when a condition changes. (You will create a rule with conditions in a following step.)
+Now that you have created a notification topic, create a subscription to that topic, so that you can receive email alerts when a condition changes. (You will create a rule with conditions in a following task.)
 
 In this lab, you create an email subscription. Subscriptions can be defined to trigger emails or pager notifications (for on-call staff whose phones will be paged.)
 
@@ -153,7 +153,7 @@ Check the email account you specified to verify that a notification email was se
 
 ## **PART 2 - Define an Alarm that Will Email a Notification When CPU Utilization Exceeds a Specific Percentage**
 
-In Steps 8 through 10, define an alarm that triggers an email when CPU utilization exceeds a percentage level that you set.
+In Tasks 8 through 10, define an alarm that triggers an email when CPU utilization exceeds a percentage level that you set.
 
 **Note:** For convenience, use the same topic and subscription that you defined in Part 1. You could define new ones, if you prefer.
 
@@ -196,14 +196,14 @@ In Steps 8 through 10, define an alarm that triggers an email when CPU utilizati
 
 - **DESTINATION SERVICE:** Select **Notifications Service**
 - **COMPARTMENT**: Select your compartment.
-- **TOPIC**: Select the topic you defined earlier in Part 1 > Step 1 of this lab.Click **Save alarm**.
+- **TOPIC**: Select the topic you defined earlier in Part 1 > Task 1 of this lab. Click **Save alarm**.
 
   ![ALT text is not available for this image](images/2619005285.png)
 
 ## Task 9: Re-run the Procedure in the Auto Scaling Lab to Create a CPU Utilization that Triggers the Alarm
 
 1. Return to this workshop's Auto Scaling lab.  
-2. In Part 2 of that lab, perform Step 5. Run the `**test_proc**` procedure concurrently in 3 SQL Developer Web query worksheet instances, which should result in CPU utilization greater than the 30% specified as the triggering level in the alarm. 
+2. In Part 2 of that lab, perform Task 5. Run the `**test_proc**` procedure concurrently in 3 SQL Developer Web query worksheet instances, which should result in CPU utilization greater than the 30% specified as the triggering level in the alarm. 
 
 ## Task 10: Verify that an Email Notification Was Sent
 

--- a/data-management-library/autonomous-database/shared/adb-loading/adb-loading-conditional.md
+++ b/data-management-library/autonomous-database/shared/adb-loading/adb-loading-conditional.md
@@ -23,7 +23,7 @@ Estimated Lab Time: 30 minutes
 -   Learn how to load data from the Object Store
 -   Learn how to troubleshoot data loads
 
-In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it with sample data from your *local file system*. In the remaining steps, you will create and load several ADW tables with sample data that you stage to an *OCI Object Store*.
+In Tasks 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it with sample data from your *local file system*. In the remaining tasks, you will create and load several ADW tables with sample data that you stage to an *OCI Object Store*.
 
 ### You Will Practice Three Loading Methods
 - **Loading Method 1**: Create and load one ADW table with sample data from your *local file system*, using the Database Actions DATA LOAD tool.
@@ -32,7 +32,7 @@ In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it
 
 ## Task 1: Download Sample Data for Loading from Local File
 
-1. For this step, you will download a .csv file containing CHANNELS information to your local computer, then use it to populate a CHANNELS_LOCAL table in your ADW database in the next step.  Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/pK5PL_ui1Q7OgZE6gh2WgR0Wyw6TiPyz7pkY5KkKUmc8NkmaccIHHHA8u0gbZnmd/n/c4u04/b/data-management-library-files/o/channels.csv" target="\_blank">here</a> to download the sample channels.csv file, saving it to a directory on your local computer.
+1. For this task, you will download a .csv file containing CHANNELS information to your local computer, then use it to populate a CHANNELS_LOCAL table in your ADW database in the next task.  Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/pK5PL_ui1Q7OgZE6gh2WgR0Wyw6TiPyz7pkY5KkKUmc8NkmaccIHHHA8u0gbZnmd/n/c4u04/b/data-management-library-files/o/channels.csv" target="\_blank">here</a> to download the sample channels.csv file, saving it to a directory on your local computer.
 
 ## Task 2: Load Local Data Using the Database Actions DATA LOAD Tool
 
@@ -82,7 +82,7 @@ In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it
 
 ## Task 3: Download Sample Data for Staging to Object Store
 
-In Steps 1 and 2, you downloaded a channels.csv file to your local computer and used the Database Actions DATA LOAD tool to create and load an ADW table. Now, you will download a zip file containing data files that you will stage to an *OCI Object Store*, to populate a number of tables in subsequent steps.
+In Tasks 1 and 2, you downloaded a channels.csv file to your local computer and used the Database Actions DATA LOAD tool to create and load an ADW table. Now, you will download a zip file containing data files that you will stage to an *OCI Object Store*, to populate a number of tables in subsequent tasks.
 
 1. Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/FNddNM_ga0qV-01p7an3Gkg4cpApXppFJwWYK_BzsH94qgZHibssWbhOHO87QUMp/n/c4u04/b/data-management-library-files/o/adb_sample_data_files.zip" target="\_blank">here</a> to download a zip file of the sample source files that you will upload to an object store that you will be defining. Unzip it to a directory on your local computer.
 
@@ -135,7 +135,7 @@ In OCI Object Storage, a bucket is the terminology for a container of multiple f
     ![Click Upload under Objects section.](images/click-upload.png " ")
 </if>
 
-3. Drag and drop, or click  **select files**,  to select all the files downloaded in Step 3. Click **Upload** and wait for the upload to complete:
+3. Drag and drop, or click  **select files**,  to select all the files downloaded in Task 3. Click **Upload** and wait for the upload to complete:
 
     ![Upload files by drag and drop or manually select files in the wizard and click upload.](images/select-files-and-upload.png " ")
 
@@ -149,7 +149,7 @@ In OCI Object Storage, a bucket is the terminology for a container of multiple f
 
     ![Select View Object Details from the ellipsis on the right of any uploaded file.](images/view-object-details.png " ")
 
-2.  Copy the base URL that points to the location of your files staged in the OCI Object Storage. *Do not include the trailing slash.* Save the base URL in a text notepad. You  will use the base URL in the upcoming steps.
+2.  Copy the base URL that points to the location of your files staged in the OCI Object Storage. *Do not include the trailing slash.* Save the base URL in a text notepad. You  will use the base URL in the upcoming tasks.
 
     ![Copy the base URL.](images/copy-base-url.png " ")
 
@@ -169,7 +169,7 @@ To load data from the Oracle Cloud Infrastructure (OCI) Object Storage, you will
 
     ![Click your username.](./images/click-your-username-livelabs.png " ")
 
-2. Make note of this username, as you will need it in an upcoming step. At the bottom left side of the page, in the **Resources** section, click **Auth Tokens**.
+2. Make note of this username, as you will need it in an upcoming task. At the bottom left side of the page, in the **Resources** section, click **Auth Tokens**.
 
     ![Click Auth Tokens under Resources at the bottom left.](./images/click-auth-tokens-livelabs.png " ")
 
@@ -181,7 +181,7 @@ To load data from the Oracle Cloud Infrastructure (OCI) Object Storage, you will
 
     ![Enter Description and click Generate Token.](./images/generate-the-token.png " ")
 
-5.  The new Auth Token is displayed. Click **Copy** to copy the Auth Token to the clipboard. Save the contents of the clipboard in your text notepad file. You will use it in the next steps.
+5.  The new Auth Token is displayed. Click **Copy** to copy the Auth Token to the clipboard. Save the contents of the clipboard in your text notepad file. You will use it in the next tasks.
 
     > **Note:** You can't retrieve the Auth Token again after closing the dialog box.
 
@@ -219,11 +219,11 @@ In the first part of this lab, you loaded data from a file that you located on y
 6. Complete the **Add Cloud Storage** page.
     + Specify the name **ADWCLab** and a description.
     + Choose **Oracle** as the cloud store, since you will be loading from your Oracle Object Store bucket.
-    + Specify the URI and bucket that you recorded in STEP 6.
+    + Specify the URI and bucket that you recorded in Task 6.
     + Use the default **Create Credential** setting. Specify the credential name **OBJ\_STORE\_CRED**.
     In order to access data in the Object Store, you have to enable your database user to authenticate itself with the Object Store using your OCI object store account and Auth Token. You do this by creating a private CREDENTIAL object for your user that stores this information encrypted in your Autonomous Data Warehouse. This information is only usable for your user schema.
     + Specify your Oracle Cloud Infrastructure user name.
-    + Copy and paste the Auth Token that you generated in STEP 7. Click **Create**.
+    + Copy and paste the Auth Token that you generated in Task 7. Click **Create**.
 
     ![Complete the Add Cloud Storage page.](./images/complete-add-cloud-storage-page-livelabs.png " ")
 
@@ -250,7 +250,7 @@ In the first part of this lab, you loaded data from a file that you located on y
 
     ![Click green arrow button to start data load job.](./images/click-green-arrow-button-start-data-load.png " ")
 
-> **Note:** The target tables loaded up to this point were for practice using the Database Tools user interface. In the next step, you will load a set of tables that will be used in subsequent labs.
+> **Note:** The target tables loaded up to this point were for practice using the Database Tools user interface. In the next task, you will load a set of tables that will be used in subsequent labs.
 
 ## Task 9: Loading Data from the Object Store Using the PL/SQL Package, DBMS_CLOUD
 
@@ -260,20 +260,20 @@ For the fastest data loading experience, Oracle recommends uploading the source 
 
 To load data from files in cloud storage into your autonomous database, use the PL/SQL `DBMS_CLOUD` package. The `DBMS_CLOUD` package supports loading data files from the following Cloud sources: Oracle Cloud Infrastructure Object Storage, Oracle Cloud Infrastructure Object Storage Classic, Amazon AWS S3, Microsoft Azure Cloud Storage, and Google Cloud Storage.
 
-This step shows how to load data from Oracle Cloud Infrastructure Object Storage using two of the procedures in the `DBMS_CLOUD` package:
+This task shows how to load data from Oracle Cloud Infrastructure Object Storage using two of the procedures in the `DBMS_CLOUD` package:
 
 + **create_credential**: Stores the object store credentials in your Autonomous Data Warehouse schema.
     + You will use this procedure to create object store credentials in your ADW admin schema.
 + **copy_data**: Loads the specified source file to a table. The table must already exist in ADW.
     + You will use this procedure to load tables to your admin schema with data from data files staged in the Oracle Cloud Infrastructure Object Storage cloud service.
 
- > **Note:** If you skipped STEP 8, in which you create a credential for object store access, please use your username and auth token from STEP 7 and run the `create_credential` procedure to create a credential. You can <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/dbms-cloud-subprograms.html#GUID-742FC365-AA09-48A8-922C-1987795CF36A" target="\_blank">click here</a> to read the documentation on how to create a credential. If you performed STEP 8, proceed.
+ > **Note:** If you skipped Task 8, in which you create a credential for object store access, please use your username and auth token from Task 7 and run the `create_credential` procedure to create a credential. You can <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/dbms-cloud-subprograms.html#GUID-742FC365-AA09-48A8-922C-1987795CF36A" target="\_blank">click here</a> to read the documentation on how to create a credential. If you performed Task 8, proceed.
 
 1. Click on the SQL tile to open SQL web developer.
 
   ![Open SQL Web Developer](images/open-sql-web-dev.png)
 
-2. Unlike the previous steps where the Database Actions DATA LOAD tool gave you the option to automatically create the target autonomous database tables during the data load process, the following steps for loading with the `DBMS_CLOUD` package require you to first create the target tables. Connected as your ADMIN user in SQL Worksheet, copy and paste <a href="./files/create_tables.txt" target="\_blank">this code snippet</a> to the worksheet. Take a moment to examine the script. You will first drop any tables with the same name before creating tables. Then click the **Run Script** button to run it.
+2. Unlike the previous tasks where the Database Actions DATA LOAD tool gave you the option to automatically create the target autonomous database tables during the data load process, the following steps for loading with the `DBMS_CLOUD` package require you to first create the target tables. Connected as your ADMIN user in SQL Worksheet, copy and paste <a href="./files/create_tables.txt" target="\_blank">this code snippet</a> to the worksheet. Take a moment to examine the script. You will first drop any tables with the same name before creating tables. Then click the **Run Script** button to run it.
 
     - It is expected that you may get *ORA-00942 table or view does not exist* errors during the `DROP TABLE` commands for the first execution of the script, but you should not see any other errors.
 
@@ -283,13 +283,13 @@ This step shows how to load data from Oracle Cloud Infrastructure Object Storage
 
 3. Download <a href="./files/load_data_without_base_url_v2.txt" target="\_blank">this code snippet</a> to a text editor.
 
-4. Replace `<bucket URI>` in the code with the base URL you copied in Step 6.  The top of the file should look similar to the example below:
+4. Replace `<bucket URI>` in the code with the base URL you copied in Task 6.  The top of the file should look similar to the example below:
 
     ```
     /* Replace <bucket URI> below with the URL you copied from your files in OCI Object Storage at runtime.
     */
     set define on
-    define &file_uri_base = 'https://objectstorage.me-dubai-1.oraclecloud.com/n/c4u04/b/LL6570-ADWLab/o'
+    define file_uri_base = 'https://objectstorage.me-dubai-1.oraclecloud.com/n/c4u04/b/LL6570-ADWLab/o'
 
     begin
      dbms_cloud.copy_data(
@@ -324,7 +324,7 @@ This step shows how to load data from Oracle Cloud Infrastructure Object Storage
     ```
     *Notice how this table lists the past and current load operations in your schema.  Any data copy and data validation operation will have backed-up records in your Cloud.*
 
-2. For an example of how to troubleshoot a data load, we will attempt to load a data file with the wrong format (chan\_v3\_error.dat).  Specifically, the default separator is the | character, but the channels_error.csv file uses a semicolon instead.  To attempt to load bad data, copy and paste <a href="./files/load_data_with_errors.txt" target="\_blank">this code snippet</a> to a SQL Worksheet and run the script as your user in SQL Worksheet. Specify the URL that points to the **chan\_v3\_error.dat** file. Use the URL that you have copied and saved in Step 6. Expect to see "Reject limit" errors when loading your data this time.
+2. For an example of how to troubleshoot a data load, we will attempt to load a data file with the wrong format (chan\_v3\_error.dat).  Specifically, the default separator is the | character, but the channels_error.csv file uses a semicolon instead.  To attempt to load bad data, copy and paste <a href="./files/load_data_with_errors.txt" target="\_blank">this code snippet</a> to a SQL Worksheet and run the script as your user in SQL Worksheet. Specify the URL that points to the **chan\_v3\_error.dat** file. Use the URL that you have copied and saved in Task 6. Expect to see "Reject limit" errors when loading your data this time.
 
     ![Paste the code and click Run Script.](images/query_results_after_loading_in_sql_dev_web.jpg " ")
 

--- a/data-management-library/autonomous-database/shared/adb-loading/adb-loading-livelabs.md
+++ b/data-management-library/autonomous-database/shared/adb-loading/adb-loading-livelabs.md
@@ -29,7 +29,7 @@ Estimated Lab Time: 30 minutes
 -   Learn how to load data from the Object Store
 -   Learn how to troubleshoot data loads
 
-In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it with sample data from your *local file system*. In the remaining steps, you will create and load several ADW tables with sample data that you stage to an *OCI Object Store*.
+In Tasks 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it with sample data from your *local file system*. In the remaining tasks, you will create and load several ADW tables with sample data that you stage to an *OCI Object Store*.
 
 ### You Will Practice Three Loading Methods
 - **Loading Method 1**: Create and load one ADW table with sample data from your *local file system*, using the Database Actions DATA LOAD tool.
@@ -38,7 +38,7 @@ In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it
 
 ## Task 1: Download Sample Data for Loading from Local File
 
-1. For this step, you will download a .csv file containing CHANNELS information to your local computer, then use it to populate a CHANNELS_LOCAL table in your ADW database in the next step.  Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/pK5PL_ui1Q7OgZE6gh2WgR0Wyw6TiPyz7pkY5KkKUmc8NkmaccIHHHA8u0gbZnmd/n/c4u04/b/data-management-library-files/o/channels.csv" target="\_blank">here</a> to download the sample channels.csv file, saving it to a directory on your local computer.
+1. For this task, you will download a .csv file containing CHANNELS information to your local computer, then use it to populate a CHANNELS_LOCAL table in your ADW database in the next task.  Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/pK5PL_ui1Q7OgZE6gh2WgR0Wyw6TiPyz7pkY5KkKUmc8NkmaccIHHHA8u0gbZnmd/n/c4u04/b/data-management-library-files/o/channels.csv" target="\_blank">here</a> to download the sample channels.csv file, saving it to a directory on your local computer.
 
 ## Task 2: Load Local Data Using the Database Actions DATA LOAD Tool
 
@@ -88,7 +88,7 @@ In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it
 
 ## Task 3: Download Sample Data for Staging to Object Store
 
-In Steps 1 and 2, you downloaded a channels.csv file to your local computer and used the Database Actions DATA LOAD tool to create and load an ADW table. Now, you will download a zip file containing data files that you will stage to an *OCI Object Store*, to populate a number of tables in subsequent steps.
+In Tasks 1 and 2, you downloaded a channels.csv file to your local computer and used the Database Actions DATA LOAD tool to create and load an ADW table. Now, you will download a zip file containing data files that you will stage to an *OCI Object Store*, to populate a number of tables in subsequent tasks.
 
 1. Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/FNddNM_ga0qV-01p7an3Gkg4cpApXppFJwWYK_BzsH94qgZHibssWbhOHO87QUMp/n/c4u04/b/data-management-library-files/o/adb_sample_data_files.zip" target="\_blank">here</a> to download a zip file of the sample source files that you will upload to an object store that you will be defining. Unzip it to a directory on your local computer.
 
@@ -120,7 +120,7 @@ In OCI Object Storage, a bucket is the terminology for a container of multiple f
 
     ![Click Upload under Objects section.](images/click-upload-livelabs.png " ")
 
-3. Drag and drop, or click  **select files**,  to select all the files downloaded in Step 3. Click **Upload** and wait for the upload to complete:
+3. Drag and drop, or click  **select files**,  to select all the files downloaded in Task 3. Click **Upload** and wait for the upload to complete:
 
     ![Upload files by drag and drop or manually select files in the wizard and click upload.](images/select-files-and-upload.png " ")
 
@@ -134,7 +134,7 @@ In OCI Object Storage, a bucket is the terminology for a container of multiple f
 
     ![Select View Object Details from the ellipsis on the right of any uploaded file.](images/view-object-details.png " ")
 
-2.  Copy the base URL that points to the location of your files staged in the OCI Object Storage. *Do not include the trailing slash.* Save the base URL in a text notepad. You  will use the base URL in the upcoming steps.
+2.  Copy the base URL that points to the location of your files staged in the OCI Object Storage. *Do not include the trailing slash.* Save the base URL in a text notepad. You  will use the base URL in the upcoming tasks.
 
     ![Copy the base URL.](images/copy-base-url.png " ")
 
@@ -154,7 +154,7 @@ To load data from the Oracle Cloud Infrastructure (OCI) Object Storage, you will
 
     ![Click your username.](./images/click-your-username-livelabs.png " ")
 
-2. Make note of this username, as you will need it in an upcoming step. At the bottom left side of the page, in the **Resources** section, click **Auth Tokens**.
+2. Make note of this username, as you will need it in an upcoming task. At the bottom left side of the page, in the **Resources** section, click **Auth Tokens**.
 
     ![Click Auth Tokens under Resources at the bottom left.](./images/click-auth-tokens-livelabs.png " ")
 
@@ -166,7 +166,7 @@ To load data from the Oracle Cloud Infrastructure (OCI) Object Storage, you will
 
     ![Enter Description and click Generate Token.](./images/generate-the-token.png " ")
 
-5.  The new Auth Token is displayed. Click **Copy** to copy the Auth Token to the clipboard. Save the contents of the clipboard in your text notepad file. You will use it in the next steps.
+5.  The new Auth Token is displayed. Click **Copy** to copy the Auth Token to the clipboard. Save the contents of the clipboard in your text notepad file. You will use it in the next tasks.
 
 > **Note:** You can't retrieve the Auth Token again after closing the dialog box.
 
@@ -204,11 +204,11 @@ In the first part of this lab, you loaded data from a file that you located on y
 6. Complete the **Add Cloud Storage** page.
     + Specify the name **ADWCLab** and a description.
     + Choose **Oracle** as the cloud store, since you will be loading from your Oracle Object Store bucket.
-    + Specify the URI and bucket that you recorded in STEP 6.
+    + Specify the URI and bucket that you recorded in Task 6.
     + Use the default **Create Credential** setting. Specify the credential name **OBJ\_STORE\_CRED**.
     In order to access data in the Object Store, you have to enable your database user to authenticate itself with the Object Store using your OCI object store account and Auth Token. You do this by creating a private CREDENTIAL object for your user that stores this information encrypted in your Autonomous Data Warehouse. This information is only usable for your user schema.
     + Specify your Oracle Cloud Infrastructure user name.
-    + Copy and paste the Auth Token that you generated in STEP 7. Click **Create**.
+    + Copy and paste the Auth Token that you generated in Task 7. Click **Create**.
 
     ![Complete the Add Cloud Storage page.](./images/complete-add-cloud-storage-page-livelabs.png " ")
 
@@ -235,7 +235,7 @@ In the first part of this lab, you loaded data from a file that you located on y
 
     ![Click green arrow button to start data load job.](./images/click-green-arrow-button-start-data-load.png " ")
 
-> **Note:** The target tables loaded up to this point were for practice using the Database Tools user interface. In the next step, you will load a set of tables that will be used in subsequent labs.
+> **Note:** The target tables loaded up to this point were for practice using the Database Tools user interface. In the next task, you will load a set of tables that will be used in subsequent labs.
 
 ## Task 9: Loading Data from the Object Store Using the PL/SQL Package, DBMS_CLOUD
 
@@ -245,14 +245,14 @@ For the fastest data loading experience, Oracle recommends uploading the source 
 
 To load data from files in cloud storage into your autonomous database, use the PL/SQL `DBMS_CLOUD` package. The `DBMS_CLOUD` package supports loading data files from the following Cloud sources: Oracle Cloud Infrastructure Object Storage, Oracle Cloud Infrastructure Object Storage Classic, Amazon AWS S3, Microsoft Azure Cloud Storage, and Google Cloud Storage.
 
-This step shows how to load data from Oracle Cloud Infrastructure Object Storage using two of the procedures in the `DBMS_CLOUD` package:
+This task shows how to load data from Oracle Cloud Infrastructure Object Storage using two of the procedures in the `DBMS_CLOUD` package:
 
 + **create_credential**: Stores the object store credentials in your Autonomous Data Warehouse schema.
     + You will use this procedure to create object store credentials in your ADW admin schema.
 + **copy_data**: Loads the specified source file to a table. The table must already exist in ADW.
     + You will use this procedure to load tables to your admin schema with data from data files staged in the Oracle Cloud Infrastructure Object Storage cloud service.
 
- > **Note:** If you skipped STEP 8, in which you create a credential for object store access, please use your username and auth token from STEP 7 and run the `create_credential` procedure to create a credential. You can <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/dbms-cloud-subprograms.html#GUID-742FC365-AA09-48A8-922C-1987795CF36A" target="\_blank">click here</a> to read the documentation on how to create a credential. If you performed STEP 8, proceed.
+ > **Note:** If you skipped Task 8, in which you create a credential for object store access, please use your username and auth token from Task 7 and run the `create_credential` procedure to create a credential. You can <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/dbms-cloud-subprograms.html#GUID-742FC365-AA09-48A8-922C-1987795CF36A" target="\_blank">click here</a> to read the documentation on how to create a credential. If you performed Task 8, proceed.
 
 1. Click on the SQL tile to open SQL web developer.
 
@@ -268,7 +268,7 @@ This step shows how to load data from Oracle Cloud Infrastructure Object Storage
 
 2. Download <a href="./files/load_data_without_base_url.txt" target="\_blank">this code snippet</a> to a text editor.
 
-3. Replace `<file_uri_base>` in the code with the base URL you copied in Step 6. You should make 10 substitutions. The top of the file should look similar to the example below:
+3. Replace `<file_uri_base>` in the code with the base URL you copied in Task 6. You should make 10 substitutions. The top of the file should look similar to the example below:
 
     ```
     begin
@@ -303,7 +303,7 @@ This step shows how to load data from Oracle Cloud Infrastructure Object Storage
     ```
     *Notice how this table lists the past and current load operations in your schema.  Any data copy and data validation operation will have backed-up records in your Cloud.*
 
-2. For an example of how to troubleshoot a data load, we will attempt to load a data file with the wrong format (chan\_v3\_error.dat).  Specifically, the default separator is the | character, but the channels_error.csv file uses a semicolon instead.  To attempt to load bad data, copy and paste <a href="./files/load_data_with_errors.txt" target="\_blank">this code snippet</a> to a SQL Worksheet and run the script as your user in SQL Worksheet. Specify the URL that points to the **chan\_v3\_error.dat** file. Use the URL that you have copied and saved in Step 6. Expect to see "Reject limit" errors when loading your data this time.
+2. For an example of how to troubleshoot a data load, we will attempt to load a data file with the wrong format (chan\_v3\_error.dat).  Specifically, the default separator is the | character, but the channels_error.csv file uses a semicolon instead.  To attempt to load bad data, copy and paste <a href="./files/load_data_with_errors.txt" target="\_blank">this code snippet</a> to a SQL Worksheet and run the script as your user in SQL Worksheet. Specify the URL that points to the **chan\_v3\_error.dat** file. Use the URL that you have copied and saved in Task 6. Expect to see "Reject limit" errors when loading your data this time.
 
     ![Paste the code and click Run Script.](images/query_results_after_loading_in_sql_dev_web.jpg " ")
 

--- a/data-management-library/autonomous-database/shared/adb-loading/adb-loading.md
+++ b/data-management-library/autonomous-database/shared/adb-loading/adb-loading.md
@@ -29,7 +29,7 @@ Estimated Lab Time: 30 minutes
 -   Learn how to load data from the Object Store
 -   Learn how to troubleshoot data loads
 
-In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it with sample data from your *local file system*. In the remaining steps, you will create and load several ADW tables with sample data that you stage to an *OCI Object Store*.
+In Tasks 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it with sample data from your *local file system*. In the remaining tasks, you will create and load several ADW tables with sample data that you stage to an *OCI Object Store*.
 
 ### You Will Practice Three Loading Methods
 - **Loading Method 1**: Create and load one ADW table with sample data from your *local file system*, using the Database Actions DATA LOAD tool.
@@ -38,7 +38,7 @@ In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it
 
 ## Task 1: Download Sample Data for Loading from Local File
 
-1. For this step, you will download a .csv file containing CHANNELS information to your local computer, then use it to populate a CHANNELS_LOCAL table in your ADW database in the next step.  Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/pK5PL_ui1Q7OgZE6gh2WgR0Wyw6TiPyz7pkY5KkKUmc8NkmaccIHHHA8u0gbZnmd/n/c4u04/b/data-management-library-files/o/channels.csv" target="\_blank">here</a> to download the sample channels.csv file, saving it to a directory on your local computer.
+1. For this task, you will download a .csv file containing CHANNELS information to your local computer, then use it to populate a CHANNELS_LOCAL table in your ADW database in the next task.  Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/pK5PL_ui1Q7OgZE6gh2WgR0Wyw6TiPyz7pkY5KkKUmc8NkmaccIHHHA8u0gbZnmd/n/c4u04/b/data-management-library-files/o/channels.csv" target="\_blank">here</a> to download the sample channels.csv file, saving it to a directory on your local computer.
 
 ## Task 2: Load Local Data Using the Database Actions DATA LOAD Tool
 
@@ -88,7 +88,7 @@ In Steps 1 and 2, you will create one ADW table, **CHANNELS_LOCAL**, and load it
 
 ## Task 3: Download Sample Data for Staging to Object Store
 
-In Steps 1 and 2, you downloaded a channels.csv file to your local computer and used the Database Actions DATA LOAD tool to create and load an ADW table. Now, you will download a zip file containing data files that you will stage to an *OCI Object Store*, to populate a number of tables in subsequent steps.
+In Tasks 1 and 2, you downloaded a channels.csv file to your local computer and used the Database Actions DATA LOAD tool to create and load an ADW table. Now, you will download a zip file containing data files that you will stage to an *OCI Object Store*, to populate a number of tables in subsequent tasks.
 
 1. Click <a href="https://objectstorage.us-ashburn-1.oraclecloud.com/p/FNddNM_ga0qV-01p7an3Gkg4cpApXppFJwWYK_BzsH94qgZHibssWbhOHO87QUMp/n/c4u04/b/data-management-library-files/o/adb_sample_data_files.zip" target="\_blank">here</a> to download a zip file of the sample source files that you will upload to an object store that you will be defining. Unzip it to a directory on your local computer.
 
@@ -124,7 +124,7 @@ In OCI Object Storage, a bucket is the terminology for a container of multiple f
 
     ![Click Upload under Objects section.](images/click-upload.png " ")
 
-3. Drag and drop, or click  **select files**,  to select all the files downloaded in Step 3. Click **Upload** and wait for the upload to complete:
+3. Drag and drop, or click  **select files**,  to select all the files downloaded in Task 3. Click **Upload** and wait for the upload to complete:
 
     ![Upload files by drag and drop or manually select files in the wizard and click upload.](images/select-files-and-upload.png " ")
 
@@ -138,7 +138,7 @@ In OCI Object Storage, a bucket is the terminology for a container of multiple f
 
     ![Select View Object Details from the ellipsis on the right of any uploaded file.](images/view-object-details.png " ")
 
-2.  Copy the base URL that points to the location of your files staged in the OCI Object Storage. *Do not include the trailing slash.* Save the base URL in a text notepad. You  will use the base URL in the upcoming steps.
+2.  Copy the base URL that points to the location of your files staged in the OCI Object Storage. *Do not include the trailing slash.* Save the base URL in a text notepad. You  will use the base URL in the upcoming tasks.
 
     ![Copy the base URL.](images/copy-base-url.png " ")
 
@@ -160,7 +160,7 @@ To load data from the Oracle Cloud Infrastructure (OCI) Object Storage, you will
 
     *Note: If you don't see your user name in the drop-down menu, you might be a "federated" user. In that case, go instead to the menu on the left side and open Users. Federated users are “federated” from another user service, whether it is an Active Directory LDAP type service or users from the older OCI Classic.*
 
-2. Make note of this username, as you will need it in an upcoming step. At the bottom left side of the page, in the **Resources** section, click **Auth Tokens**.
+2. Make note of this username, as you will need it in an upcoming task. At the bottom left side of the page, in the **Resources** section, click **Auth Tokens**.
 
     ![Click Auth Tokens under Resources at the bottom left.](./images/click-auth-tokens.png " ")
 
@@ -172,7 +172,7 @@ To load data from the Oracle Cloud Infrastructure (OCI) Object Storage, you will
 
     ![Enter Description and click Generate Token.](./images/generate-the-token.png " ")
 
-5.  The new Auth Token is displayed. Click **Copy** to copy the Auth Token to the clipboard. Save the contents of the clipboard in your text notepad file. You will use it in the next steps. *Note: You can't retrieve the Auth Token again after closing the dialog box.*
+5.  The new Auth Token is displayed. Click **Copy** to copy the Auth Token to the clipboard. Save the contents of the clipboard in your text notepad file. You will use it in the next tasks. *Note: You can't retrieve the Auth Token again after closing the dialog box.*
 
     ![Copy the Auth Token to clipboard.](./images/generated-token.png " ")
 
@@ -208,11 +208,11 @@ In the first part of this lab, you loaded data from a file that you located on y
 6. Complete the **Add Cloud Storage** page.
     + Specify the name **ADWCLab** and a description.
     + Choose **Oracle** as the cloud store, since you will be loading from your Oracle Object Store bucket.
-    + Specify the URI and bucket that you recorded in STEP 6.
+    + Specify the URI and bucket that you recorded in Task 6.
     + Use the default **Create Credential** setting. Specify the credential name **OBJ\_STORE\_CRED**.
     In order to access data in the Object Store, you have to enable your database user to authenticate itself with the Object Store using your OCI object store account and Auth Token. You do this by creating a private CREDENTIAL object for your user that stores this information encrypted in your Autonomous Data Warehouse. This information is only usable for your user schema.
     + Specify your Oracle Cloud Infrastructure user name.
-    + Copy and paste the Auth Token that you generated in STEP 7. Click **Create**.
+    + Copy and paste the Auth Token that you generated in Task 7. Click **Create**.
 
     ![Complete the Add Cloud Storage page.](./images/complete-add-cloud-storage-page.png " ")
 
@@ -239,7 +239,7 @@ In the first part of this lab, you loaded data from a file that you located on y
 
     ![Click green arrow button to start data load job.](./images/click-green-arrow-button-start-data-load.png " ")
 
-**Note:** The target tables loaded up to this point were for practice using the Database Tools user interface. In the next step, you will load a set of tables that will be used in subsequent labs.
+**Note:** The target tables loaded up to this point were for practice using the Database Tools user interface. In the next task, you will load a set of tables that will be used in subsequent labs.
 
 ## Task 9: Loading Data from the Object Store Using the PL/SQL Package, DBMS_CLOUD
 
@@ -249,14 +249,14 @@ For the fastest data loading experience, Oracle recommends uploading the source 
 
 To load data from files in cloud storage into your autonomous database, use the PL/SQL `DBMS_CLOUD` package. The `DBMS_CLOUD` package supports loading data files from the following Cloud sources: Oracle Cloud Infrastructure Object Storage, Oracle Cloud Infrastructure Object Storage Classic, Amazon AWS S3, Microsoft Azure Cloud Storage, and Google Cloud Storage.
 
-This step shows how to load data from Oracle Cloud Infrastructure Object Storage using two of the procedures in the `DBMS_CLOUD` package:
+This task shows how to load data from Oracle Cloud Infrastructure Object Storage using two of the procedures in the `DBMS_CLOUD` package:
 
 + **create_credential**: Stores the object store credentials in your Autonomous Data Warehouse schema.
     + You will use this procedure to create object store credentials in your ADW admin schema.
 + **copy_data**: Loads the specified source file to a table. The table must already exist in ADW.
     + You will use this procedure to load tables to your admin schema with data from data files staged in the Oracle Cloud Infrastructure Object Storage cloud service.
 
-***Note:*** If you skipped STEP 8, in which you create a credential for object store access, please use your username and auth token from STEP 7 and run the `create_credential` procedure to create a credential. You can <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/dbms-cloud-subprograms.html#GUID-742FC365-AA09-48A8-922C-1987795CF36A" target="\_blank">click here</a> to read the documentation on how to create a credential. If you performed STEP 8, proceed with the following:
+***Note:*** If you skipped Task 8, in which you create a credential for object store access, please use your username and auth token from Task 7 and run the `create_credential` procedure to create a credential. You can <a href="https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/dbms-cloud-subprograms.html#GUID-742FC365-AA09-48A8-922C-1987795CF36A" target="\_blank">click here</a> to read the documentation on how to create a credential. If you performed Task 8, proceed with the following:
 
 1. Click on the SQL tile to open SQL web developer.
 
@@ -272,7 +272,7 @@ This step shows how to load data from Oracle Cloud Infrastructure Object Storage
 
 2. Download <a href="./files/load_data_without_base_url.txt" target="\_blank">this code snippet</a> to a text editor.
 
-3. Replace `<file_uri_base>` in the code with the base URL you copied in Step 6. You should make 10 substitutions. The top of the file should look similar to the example below:
+3. Replace `<file_uri_base>` in the code with the base URL you copied in Task 6. You should make 10 substitutions. The top of the file should look similar to the example below:
 
     ```
     begin
@@ -307,7 +307,7 @@ This step shows how to load data from Oracle Cloud Infrastructure Object Storage
     ```
     *Notice how this table lists the past and current load operations in your schema.  Any data copy and data validation operation will have backed-up records in your Cloud.*
 
-2. For an example of how to troubleshoot a data load, we will attempt to load a data file with the wrong format (chan\_v3\_error.dat).  Specifically, the default separator is the | character, but the channels_error.csv file uses a semicolon instead.  To attempt to load bad data, copy and paste <a href="./files/load_data_with_errors.txt" target="\_blank">this code snippet</a> to a SQL Worksheet and run the script as your user in SQL Worksheet. Specify the URL that points to the **chan\_v3\_error.dat** file. Use the URL that you have copied and saved in Step 6. Expect to see "Reject limit" errors when loading your data this time.
+2. For an example of how to troubleshoot a data load, we will attempt to load a data file with the wrong format (chan\_v3\_error.dat).  Specifically, the default separator is the | character, but the channels_error.csv file uses a semicolon instead.  To attempt to load bad data, copy and paste <a href="./files/load_data_with_errors.txt" target="\_blank">this code snippet</a> to a SQL Worksheet and run the script as your user in SQL Worksheet. Specify the URL that points to the **chan\_v3\_error.dat** file. Use the URL that you have copied and saved in Task 6. Expect to see "Reject limit" errors when loading your data this time.
 
     ![Paste the code and click Run Script.](images/query_results_after_loading_in_sql_dev_web.jpg " ")
 

--- a/data-management-library/autonomous-database/shared/adb-query/adb-query.md
+++ b/data-management-library/autonomous-database/shared/adb-query/adb-query.md
@@ -39,11 +39,11 @@ Estimated Lab Time: 10 minutes
 
 7.  Download <a href="./files/create_external_tables_without_base_url_v2.txt" target="\_blank">this code snippet</a> to a text editor.
 
-8.  Replace `<bucket URI>` in the code with the base URL you copied in Loading Data Lab, Step 6.
+8.  Replace `<bucket URI>` in the code with the base URL you copied in Loading Data Lab, Task 6.
 
     This code uses the **create\_external\_table** procedure of the **DBMS\_CLOUD** package to create external tables on the files staged in your object store. Note that you are still using the same credential and URLs of files on OCI Object Storage you used when loading data in Loading Data Lab.
 
-9.  Run the script in SQL Worksheet. In the Substitutions Variables dialog, paste the base URL you copied in Loading Data Lab, Step 6, and click **OK**.
+9.  Run the script in SQL Worksheet. In the Substitutions Variables dialog, paste the base URL you copied in Loading Data Lab, Task 6, and click **OK**.
 
     ![Click Run Script.](images/step1.5.png " ")
 

--- a/data-management-library/autonomous-database/shared/adw-machine-learning/adw-machine-learning.md
+++ b/data-management-library/autonomous-database/shared/adw-machine-learning/adw-machine-learning.md
@@ -39,7 +39,7 @@ The first step is to download the sample notebook and then import it into the Or
 
 ## Task 5: Select the lab notebook .json file you downloaded earlier
 
-1. Select the lab notebook **Basic\_Machine\_Learning.json** file you downloaded previously in Step 1.
+1. Select the lab notebook **Basic\_Machine\_Learning.json** file you downloaded previously in Task 1.
 
     ![](./images/snap0014523.jpg " ")
 

--- a/data-management-library/autonomous-database/shared/adw-oml-notebooks/adw-oml-notebooks.md
+++ b/data-management-library/autonomous-database/shared/adw-oml-notebooks/adw-oml-notebooks.md
@@ -243,7 +243,7 @@ By default, when you create a notebook, it’s only visible to you. To make it a
 
 ## Task 10: Accessing shared notebooks
 
-1.  Now, repeat the process you followed at Step 8. Sign out of OML as **OMLUSER1** and sign in to OML again as user **OMLUSER2**.
+1.  Now, repeat the process you followed at Task 8. Sign out of OML as **OMLUSER1** and sign in to OML again as user **OMLUSER2**.
 
     First thing to note is that the **Recent Activities** panel below the **Quick Actions** panel now shows all the changes user OMLUSER1 made within the *OML Project [OML Workspace]*.
 

--- a/data-management-library/autonomous-database/shared/adw-visualizations/adw-visualizations.md
+++ b/data-management-library/autonomous-database/shared/adw-visualizations/adw-visualizations.md
@@ -12,7 +12,7 @@ This lab will walk you through the steps to connect *Oracle Analytics Desktop* (
 
 ## Task 1: Install Oracle Analytics Desktop on a Windows Desktop
 
-1. Download the latest version of *Oracle Analytics Desktop* (formerly Data Visualization Desktop) from <a href="http://www.oracle.com/technetwork/middleware/oracle-data-visualization/downloads/oracle-data-visualization-desktop-2938957.html" target="\_blank"> here</a>.
+1. Download *version 5.9* of *Oracle Analytics Desktop* (formerly Data Visualization Desktop) from Oracle Software Delivery Cloud <a href="https://edelivery.oracle.com/osdc/faces/SoftwareDelivery" target="\_blank"> here</a>. Do not use version 6.x of Oracle Analytics Desktop.
 
 2. After saving the installer executable file, click on the installer and follow the guided steps.
 
@@ -120,7 +120,7 @@ As ADW and ATP accept only secure connections to the database, you need to downl
    | --------------------- | :--------------------------------------------- |
    | Connection Name:      | Type in '**SALES_HISTORY**'                             |
    | Service Name:         | Scroll the drop-down field and select **adwfinance_high**, or the **high** service level of the database name you specified in Lab 1. |
-   | Client Credentials:   | Click '**Select...**' and select the wallet zip file that you downloaded in Step 3.3. A file with .sso extension will appear in the field.   |
+   | Client Credentials:   | Click '**Select...**' and select the wallet zip file that you downloaded in Task 3.3. A file with .sso extension will appear in the field.   |
    | Username:             | Insert username created in previous labs, likely **ADMIN**.  Same username as SQL Worksheet and SQL Developer credentials. |                                            
    | Password              | Insert password created in previous labs.  Same password as SQL Worksheet and SQL Developer credentials. |
 
@@ -191,9 +191,9 @@ No matter what your role is in the organization, access to data timely can provi
 
  You may **Save** this project if you need. At this point, with very few steps, you now have something that can further bring your data to life and you can begin to make some data-driven decisions.  As you share this with others, more people will want to gain access to and benefit from the data. To enable this, the Oracle Autonomous Database in ADW or ATP is easy to use, fast, elastic, and will be able to quickly scale to meet your growing data and user base.
 
-## (Optional) **STEP 6**: Exporting your DVA (project) File
+## (Optional) **Task 6**: Exporting your DVA (project) File
 
-This step enables you to share your project file with colleagues.
+This task enables you to share your project file with colleagues.
 
 1. Click the menu at the top left corner of the screen, and select __Home__.
 

--- a/data-management-library/autonomous-database/shared/workshops/adbs-tools/getting-started/getting-started.md
+++ b/data-management-library/autonomous-database/shared/workshops/adbs-tools/getting-started/getting-started.md
@@ -70,7 +70,7 @@ For this workshop we need to create one new user.
   - Select **UNLIMITED** from the drop down menu for Quota on tablespace DATA
   - Leave the **Password Expired** toggle button as off (note this controls whether the user will be prompted to change their password when they next login).
   - Leave the **Account is locked **toggle button as off. 
-  
+
 Next you will examine the form.
 
 6. When you examine the form, it should look like this:
@@ -93,7 +93,7 @@ Now you need to switch to working as the user QTEAM, so you can start the next l
 
   ![ALT text is not available for this image](images/click-qteam.png)
 
-2. Enter the username QTEAM and the password you defined in Step 2 when you created this user.
+2. Enter the username QTEAM and the password you defined in Task 1 when you created this user.
 
   ![ALT text is not available for this image](images/qteam-login.png)
 

--- a/data-management-library/autonomous-database/shared/workshops/adbs-tools/using-adb-tools/using-adb-tools.md
+++ b/data-management-library/autonomous-database/shared/workshops/adbs-tools/using-adb-tools/using-adb-tools.md
@@ -172,7 +172,7 @@ Below are the four files that you will be using during this part of the workshop
   ![ALT text is not available for this image](images/green-button.png)
   The time taken to load each file depends on factors including file size and network speed. The progress of the job can be monitored from the status bar and the ring to the left of each job card. When the ring is complete, the file has uploaded successfully. 
   ![ALT text is not available for this image](images/loading.png)
-  
+
 
 Now let's inspect the tables that were automatically created during the data load process.
 
@@ -272,11 +272,11 @@ During data load from Object Storage, Autonomous Data Warehouse creates a number
 34. Drop the tables as follows:
 
     a. Click the **refresh** button (circular arrows) to see the full list of tables in the schema and identify the logging tables.
-    
+
     b. For each table type, drop table {TABLE NAME} in the SQL Worksheet.
-    
+
     c. Click the green **Run** button.
-    
+
     d. Confirm the successful deletion in the Script Output pane.
   ![ALT text is not available for this image](images/drop-table.png)
 
@@ -459,14 +459,14 @@ Watch a video demonstration of the Data Insights tool of Autonomous Database:
 [] (youtube:pLaZnCQk3Vs)
 > **Note:** Interfaces in this video may look different from the interfaces you will see.
 
-### Generat New Insights
+### Generate New Insights
 
 1. From the Autonomous Database **Tools** home page, click the **Data Insights** card. If this is the first time you've accessed this tool (or any other in the Built-In Tool Suite), you'll see a series of tool tips to show you how to use it.
   ![ALT text is not available for this image](images/2879071206.png)
 2. If the tool tips do not appear, they can be accessed by Clicking the binoculars icon on the upper-right of the screen (under your username). Click **Next** repeatedly to browse through the tool tips for the Data Insights module. (To exit at any time, press X in the upper right of the tool tip.)
 3. In this exercise you're going to follow a procedure exactly as laid out in these tool tips, thus:
 
-    a. Under **Resource**, select Analytic View MOVIE\_SALES\_2020Q2\_MODEL\_AV (which is the basis for the Business Model you created in Step 3). 
+    a. Under **Resource**, select Analytic View MOVIE\_SALES\_2020Q2\_MODEL\_AV (which is the basis for the Business Model you created in Task 3). 
 
     b. Under **Column**, select PURCHASES.
 


### PR DESCRIPTION
…TEP" to "Task" in the wording of instructional steps in a number of ADW labs

In "Load Data Into an Autonomous Database Instance" lab
\shared\adb-loading\adb-loading-conditional.md
Task 9, step 4: removed ampersand from the "set define on" statement
Also, across a number of labs in several ADW workshops, changed "STEP" and "step"  to "Task" and "task" in the instructional sentences that referenced a previous STEP. This complements Tom McGinn's global change of "STEP" to "Task".