### PR TITLE
Workshop ID#6481 fix Lab 3 code snippet to remove reference to db_use…

### DIFF
--- a/data-management-library/autonomous-database/shared/movie-stream-story/apply-spatial/apply-spatial.md
+++ b/data-management-library/autonomous-database/shared/movie-stream-story/apply-spatial/apply-spatial.md
@@ -8,11 +8,11 @@ Estimated Lab Time: 20 minutes
 
 ### About Product/Technology
 
-Oracle Database, including Oracle Autonomous Database, provides native support for spatial data management, analysis, and processing. Oracle Database stores spatial data (points, lines, polygons) in a native data type called SDO_GEOMETRY. Oracle Database also provides a native spatial index for high performance spatial queries. This spatial index relies on spatial metadata that is entered for each geometry column storing spatial data. Once spatial data is populated and indexed, robust APIs are available to perform spatial analysis, calculations, and processing.  A self-service web application, Spatial Studio, is also available for no-code access to the Spatial features of Oracle Database. 
+Oracle Database, including Oracle Autonomous Database, provides native support for spatial data management, analysis, and processing. Oracle Database stores spatial data (points, lines, polygons) in a native data type called SDO_GEOMETRY. Oracle Database also provides a native spatial index for high performance spatial queries. This spatial index relies on spatial metadata that is entered for each geometry column storing spatial data. Once spatial data is populated and indexed, robust APIs are available to perform spatial analysis, calculations, and processing.  A self-service web application, Spatial Studio, is also available for no-code access to the Spatial features of Oracle Database.
 
 ![Image alt text](images/spatial.png "Oracle Spatial")
 
-To add spatial capability to a table, we can add and populate a column of type SDO_GEOMETRY and then create a spatial index. In the case of large tables it would be preferable to enable spatial capability without having to create a new column. Fortunately, Spatial is a first-class feature of Oracle Database and, as such, is able to leverage many powerful mainstream Oracle features.  One such feature is **[function-based indexes](https://docs.oracle.com/en/database/oracle/oracle-database/19/cncpt/indexes-and-index-organized-tables.html#GUID-9AD7651D-0F0D-4FC6-A984-5845F0224EE6)**, which allows creating an index on the result of a SQL function. This is a perfect for Spatial: we create a function that accepts coordinates and returns SDO\_GEOMETRY, and then create a spatial index on the output of that function. Using a function-based spatial index, our table is enabled for spatial analysis without the need to to add a geometry column.
+To add spatial capability to a table, we can add and populate a column of type SDO_GEOMETRY and then create a spatial index. In the case of large tables it would be preferable to enable spatial capability without having to create a new column. Fortunately, Spatial is a first-class feature of Oracle Database and, as such, is able to leverage many powerful mainstream Oracle features.  One such feature is **[function-based indexes](https://docs.oracle.com/en/database/oracle/oracle-database/19/cncpt/indexes-and-index-organized-tables.html#GUID-9AD7651D-0F0D-4FC6-A984-5845F0224EE6)**, which allows creating an index on the result of a SQL function. This is a perfect for Spatial: we create a function that accepts coordinates and returns SDO\_GEOMETRY, and then create a spatial index on the output of that function. Using a function-based spatial index, our table is enabled for spatial analysis without the need to add a geometry column.
 
 For a hands-on general introduction, you are encouraged to review **[Introduction to Oracle Spatial Workshop] (https://apexapps.oracle.com/pls/apex/dbpm/r/livelabs/view-workshop?wid=736)**
 
@@ -36,9 +36,9 @@ To prepare your data for spatial analyses, you create function-based spatial ind
 
 
 1. As described in Lab 4 Step 3, navigate to a SQL Worksheet as user MOVIESTREAM.
-   
+
 2. Begin by creating a function that accepts coordinates and returns a geometry. In order to use a function for a function-based index, it must be declared DETERMINISTIC. This means that a given input will always return the same output.  Our case of returning a geometry from latitude, longitude input meets this requirement. Run the following command to create the function.
- 
+
     ```
 	<copy>
     CREATE OR REPLACE FUNCTION latlon_to_geometry (
@@ -49,8 +49,8 @@ To prepare your data for spatial analyses, you create function-based spatial ind
    IS
    BEGIN
        --first ensure valid lat/lon input
-       IF latitude IS NULL OR longitude IS NULL 
-       OR latitude NOT BETWEEN -90 AND 90 
+       IF latitude IS NULL OR longitude IS NULL
+       OR latitude NOT BETWEEN -90 AND 90
        OR longitude NOT BETWEEN -180 AND 180 THEN
          RETURN NULL;
        ELSE
@@ -59,14 +59,14 @@ To prepare your data for spatial analyses, you create function-based spatial ind
                 2001, --identifier for a point geometry
                 4326, --identifier for lat/lon coordinate system
                 sdo_point_type(
-                 longitude, latitude, NULL), 
+                 longitude, latitude, NULL),
                 NULL, NULL);
        END IF;
    END;
    </copy>
     ```
 
-3. Next test the function. Since the function returns a point geometry, you can perform a basic distance calculation using function calls to create the input geometries. Operations that do not involve spatial search or filtering, such as distance between 2 points, do not require a spatial index. Therefore you are able to perform this operation now, before spatial metadata and indexes are created. Run the following query to test the function by calculating the distance between a pair of coordinates.
+3. Next, test the function. Since the function returns a point geometry, you can perform a basic distance calculation using function calls to create the input geometries. Operations that do not involve spatial search or filtering, such as distance between 2 points, do not require a spatial index. Therefore you are able to perform this operation now, before spatial metadata and indexes are created. Run the following query to test the function by calculating the distance between a pair of coordinates.
 
     ```
     <copy>
@@ -81,7 +81,7 @@ To prepare your data for spatial analyses, you create function-based spatial ind
 
     ![Image alt text](images/spatial-02.png "Test the function")
 
-4. Before creating a spatial index, you must insert a row of metadata for the geometry being indexed. This metadata is stored in a centralized spatial metadata table exposed to users through the view USER\_SDO\_GEOM\_METADATA available to all users. Instead of creating a spatial indexe on a geometry column, you will be creating function-based spatial indexes. Therefore you insert spatial metadata specifying the function instead of a column. It is required that the function name be prefixed with the owner name. Run the following commands to insert spatial metadata for the CUSTOMER\_CONTACT and PIZZA\_LOCATION tables.
+4. Before creating a spatial index, you must insert a row of metadata for the geometry being indexed. This metadata is stored in a centralized spatial metadata table exposed to users through the view USER\_SDO\_GEOM\_METADATA available to all users. Instead of creating a spatial index on a geometry column, you will be creating function-based spatial indexes. Therefore you insert spatial metadata specifying the function instead of a column. It is required that the function name be prefixed with the owner name. Run the following commands to insert spatial metadata for the CUSTOMER\_CONTACT and PIZZA\_LOCATION tables.
 
     ```
     <copy>
@@ -98,7 +98,7 @@ To prepare your data for spatial analyses, you create function-based spatial ind
      'PIZZA_LOCATION',
      user||'.LATLON_TO_GEOMETRY(lat,lon)',
       sdo_dim_array(
-          sdo_dim_element('X', -180, 180, 0.05), 
+          sdo_dim_element('X', -180, 180, 0.05),
           sdo_dim_element('Y', -90, 90, 0.05)),
       4326
        );
@@ -109,23 +109,23 @@ To prepare your data for spatial analyses, you create function-based spatial ind
 
     ```
     <copy>
-    CREATE INDEX customer_sidx 
+    CREATE INDEX customer_sidx
     ON customer_contact (latlon_to_geometry(loc_lat,loc_long))
-    INDEXTYPE IS mdsys.spatial_index_v2 
+    INDEXTYPE IS mdsys.spatial_index_v2
        PARAMETERS ('layer_gtype=POINT');
 
-    CREATE INDEX pizza_location_sidx 
+    CREATE INDEX pizza_location_sidx
     ON pizza_location (latlon_to_geometry(lat,lon))
-    INDEXTYPE IS mdsys.spatial_index_v2 
+    INDEXTYPE IS mdsys.spatial_index_v2
        PARAMETERS ('layer_gtype=POINT');
     </copy>
     ```
 
 ## Task 2: Run Spatial Queries
 
-Oracle Autonomous Database provides an extensive SQL API for spatial analysis. This includes spatial relationships, measurements, aggregations, transformations, and more. In this lab you focus on one of those spatial analysis operations; "nearest neighbor" analysis. Nearest neighbor analysis refers to identifying which item(s) are nearest to a location. 
+Oracle Autonomous Database provides an extensive SQL API for spatial analysis. This includes spatial relationships, measurements, aggregations, transformations, and more. In this lab you focus on one of those spatial analysis operations; "nearest neighbor" analysis. Nearest neighbor analysis refers to identifying which item(s) are nearest to a location.
 
-The neareat neighbor SQL operator is called ```sdo_nn( )``` as has the general form 
+The nearest neighbor SQL operator is called ```sdo_nn( )``` and it has the general form:
 
 ```
 sdo_nn(
@@ -136,7 +136,7 @@ parameters --how many nearest neighbors to return
 ```
 and returns the item(s) in ```geometry1``` that are nearest to ```geometry2```.
 
-In this lab, instead of creating geometry columns you are using your ```latlon_to_geometry( )``` function to return geometries, so that function will be used to feed geometry to the ```sdo_nn( )``` operator. 
+In this lab, instead of creating geometry columns you are using your ```latlon_to_geometry( )``` function to return geometries, so that function will be used to feed geometry to the ```sdo_nn( )``` operator.
 
 There are 2 scenarios for a nearest neighbor query: search all items for nearest neighbor(s), or search only a subset of items. Using pizza locations as an example for these scenarios:
 
@@ -156,7 +156,7 @@ This lab is based on scenario 1.  Scenario 2 requires a slightly different synta
     FROM customer_contact a, pizza_location b
     WHERE a.cust_id = 1029765
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
          'sdo_num_res=1') = 'TRUE';
     </copy>
@@ -172,7 +172,7 @@ This lab is based on scenario 1.  Scenario 2 requires a slightly different synta
     FROM customer_contact a, pizza_location b
     WHERE a.cust_id = 1029765
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
          'sdo_num_res=5') = 'TRUE';
     </copy>
@@ -184,22 +184,22 @@ This lab is based on scenario 1.  Scenario 2 requires a slightly different synta
 
     ```
     <copy>
-    SELECT b.chain, b.address, b.city, b.state, 
+    SELECT b.chain, b.address, b.city, b.state,
            round( sdo_nn_distance(1), 1 ) distance_km
     FROM customer_contact a, pizza_location  b
     WHERE a.cust_id = 1029765
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
-         'sdo_num_res=1 unit=KM', 
+         'sdo_num_res=1 unit=KM',
          1 ) = 'TRUE';
     </copy>
     ```
-   
+
     ![Image alt text](images/spatial-07.png "Nearest neighbor query")
 
  4. To return the 5 nearest pizza locations with distance, update the sdo\_num\_res parameter from 1 to 5 and re-run. Notice the addition of ORDER BY to order results by distance.
- 
+
     ```
     <copy>
     SELECT b.chain, b.address, b.city, b.state,
@@ -207,30 +207,30 @@ This lab is based on scenario 1.  Scenario 2 requires a slightly different synta
     FROM customer_contact a, pizza_location  b
     WHERE a.cust_id = 1029765
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
          'sdo_num_res=5 unit=KM',
          1 ) = 'TRUE'
     ORDER BY distance_km;
     </copy>
     ```
- 
+
     ![Image alt text](images/spatial-08.png "Nearest neighbor query")
 
-   
+
 5. The previous queries identified pizza locations nearest to a single customer location (i.e. customer 1019429). You can also use the sdo_nn( ) operator to identify the nearest pizza location for a set of customer locations. This is a **nearest neighbor join**, where pizza and customer locations are joined based on the nearest neighbor relationship. Run the following query to identify the nearest pizza location for all customers in Rhode Island.
 
     ```
     <copy>
-    SELECT a.cust_id, b.chain, b.address, b.city, b.state, 
+    SELECT a.cust_id, b.chain, b.address, b.city, b.state,
            round( sdo_nn_distance(1), 1 ) distance_km
     FROM customer_contact a, pizza_location b
     WHERE a.state_province = 'Rhode Island'
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
-         'sdo_num_res=1 unit=KM', 
-         1 ) = 'TRUE'; 
+         'sdo_num_res=1 unit=KM',
+         1 ) = 'TRUE';
     </copy>
     ```
 
@@ -240,73 +240,73 @@ This lab is based on scenario 1.  Scenario 2 requires a slightly different synta
 
     ```
     <copy>
-    SELECT a.cust_id, b.chain, b.address, b.city, b.state, 
+    SELECT a.cust_id, b.chain, b.address, b.city, b.state,
           round( sdo_nn_distance(1), 1
           ) distance_km
     FROM customer_contact a, pizza_location b
     WHERE a.state_province = 'Rhode Island'
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
          'sdo_num_res=1 distance=3 unit=KM',
-         1 ) = 'TRUE'; 
+         1 ) = 'TRUE';
     </copy>
     ```
 
     ![Image alt text](images/spatial-10.png "Nearest neighbor query")
 
-   In the above query, supplying a maximum distance parameter is preferred over adding a predicate on ```distance_km```. This is because the distance parameter specifies no search for nearest items beyond the distance threshold, while a distance predicate searches all for nearest items, calulates distances, and then filters.
+   In the above query, supplying a maximum distance parameter is preferred over adding a predicate on ```distance_km```. This is because the distance parameter specifies no search for nearest items beyond the distance threshold, while a distance predicate searches all for nearest items, calculates distances, and then filters.
 
 7. Adjust the maximum distance threshold from 3km to 10km and observe the results change.
 
     ```
     <copy>
-    SELECT a.cust_id, b.chain, b.address, b.city, b.state, 
+    SELECT a.cust_id, b.chain, b.address, b.city, b.state,
            round( sdo_nn_distance(1), 1 ) distance_km
     FROM customer_contact a, pizza_location b
     WHERE a.state_province = 'Rhode Island'
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
-         'sdo_num_res=1 distance=10 unit=KM', 
-         1 ) = 'TRUE'; 
+         'sdo_num_res=1 distance=10 unit=KM',
+         1 ) = 'TRUE';
     </copy>
     ```
-    
+
     ![Image alt text](images/spatial-11.png "Nearest neighbor query")
 
 8. You are now ready to identify the nearest pizza partner location for all customers. This promotion is designed to be run as a national campaign in the United States, so the pizza locations we're using in this exercise are restricted to that market. Run the following query to identify the nearest pizza locations using a maximum search distance of 10km.
 
     ```
     <copy>
-    SELECT a.cust_id, b.chain, b.address, b.city, b.state, 
+    SELECT a.cust_id, b.chain, b.address, b.city, b.state,
            round( sdo_nn_distance(1), 1 ) distance_km
     FROM customer_contact a, pizza_location b
     WHERE a.country = 'United States'
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
-         'sdo_num_res=1 distance=10 unit=KM', 
+         'sdo_num_res=1 distance=10 unit=KM',
          1 ) = 'TRUE';
     </copy>
     ```
-    
+
     ![Image alt text](images/spatial-12.png "Nearest neighbor query")
 
-9. Create a table from this result so that it can be joined with Machine Learning churn predictions. From this combination of results a promotion can be created.
+9. Create a table from this result so that it can be joined with Machine Learning churn predictions. From this combination of results, a promotion can be created.
 
     ```
     <copy>
-    CREATE TABLE customer_nearest_pizza 
+    CREATE TABLE customer_nearest_pizza
     AS
-    SELECT a.cust_id, b.chain, b.address, b.city, b.state, 
+    SELECT a.cust_id, b.chain, b.address, b.city, b.state,
            round( sdo_nn_distance(1), 1 ) distance_km
     FROM customer_contact a, pizza_location b
     WHERE a.country = 'United States'
     AND sdo_nn(
-         latlon_to_geometry(b.lat, b.lon), 
+         latlon_to_geometry(b.lat, b.lon),
          latlon_to_geometry(a.loc_lat, a.loc_long),
-         'sdo_num_res=1 distance=10 unit=KM', 
+         'sdo_num_res=1 distance=10 unit=KM',
          1 ) = 'TRUE';
     </copy>
     ```
@@ -314,7 +314,7 @@ This lab is based on scenario 1.  Scenario 2 requires a slightly different synta
 ###Performance and Scaling
 Parallel processing is a powerful capability of Oracle database for high performance and scalability. Parallelized operations are spread across database server processors, where performance generally increases linearly with the "degree of parallelism" (DOP). DOP can be thought of as the number of processors that the operation is spread over. Many spatial operations of Oracle database support parallel processing, including nearest neighbor.
 
-In customer-managed (non-Autonomous) Oracle Database, the degree of parallelism is set using optimizer hints. In Oracle Autonomous Database, parallelism is ... you guessed it... autonomous.  A feature called "auto-DOP" controls parallelism based on available processing resources for the database session. Those available processing resources are in turn based on; 1) the service used for the current session: (service)\_LOW, (service)\_MEDIUM, or (service)\_HIGH, and 2) the shape (total OCPUs) of the Autonomous Database. Changing your connection from LOW to MEDIUM to HIGH  will increase the degree of parallelism and consume more of the overall processing resources for other operations.  So a balance must be reached between optimal performance and sufficient resources for all workloads. Details can be found in the documention [here](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/manage-priorities.html#GUID-19175472-D200-445F-897A-F39801B0E953).
+In customer-managed (non-Autonomous) Oracle Database, the degree of parallelism is set using optimizer hints. In Oracle Autonomous Database, parallelism is ... you guessed it... autonomous.  A feature called "auto-DOP" controls parallelism based on available processing resources for the database session. Those available processing resources are in turn based on; 1) the service used for the current session: (service)\_LOW, (service)\_MEDIUM, or (service)\_HIGH, and 2) the shape (total OCPUs) of the Autonomous Database. Changing your connection from LOW to MEDIUM to HIGH  will increase the degree of parallelism and consume more of the overall processing resources for other operations.  So a balance must be reached between optimal performance and sufficient resources for all workloads. Details can be found in the documentation [here](https://docs.oracle.com/en/cloud/paas/autonomous-database/adbsa/manage-priorities.html#GUID-19175472-D200-445F-897A-F39801B0E953).
 
 ## Task 3: Purge changes (Optional)
 
@@ -336,7 +336,7 @@ If you would like to purge all changes made in this lab, run the following comma
 You may now [proceed to the next lab](#next).
 
 ## Learn More
-* [Spatial product portal] (https://oracle.com/goto/spatial)
+* [Spatial product portal](https://www.oracle.com/database/spatial/)
 * [Spatial documention](https://docs.oracle.com/en/database/oracle/oracle-database/21/spatl/index.html)
 * [Spatial blogs](https://blogs.oracle.com/oraclespatial/)
 
@@ -344,5 +344,3 @@ You may now [proceed to the next lab](#next).
 * **Author** - David Lapp, Database Product Management, Oracle
 * **Contributors** -  Marty Gubar, Patrick Wheeler, Keith Laker, Rick Green
 * **Last Updated By/Date** - David Lapp, July 2021
-
-

--- a/data-management-library/autonomous-database/shared/movie-stream-story/create-db-user/create-db-user.md
+++ b/data-management-library/autonomous-database/shared/movie-stream-story/create-db-user/create-db-user.md
@@ -112,7 +112,7 @@ You learned how to use the Create User dialog to create a new user.  You can als
     begin
     ords_admin.enable_schema (
         p_enabled               => TRUE,
-        p_schema                => '&db_user',
+        p_schema                => 'moviestream',
         p_url_mapping_type      => 'BASE_PATH',
         p_auto_rest_auth        => TRUE
     );


### PR DESCRIPTION
…r variable; also intial edits to David Lapp's Spatial Lab 7

We switched last week from the buggy UI to SQL Worksheet to grant additional roles. We first tried a variable for db_user, but when we got errors, we switched back to simply specifying "moviestream" as the user name. But we missed fixing the line:  p_schema => '&db_user'
I changed it to  p_schema => 'moviestream', so the learner isn't prompted for a db_user substitution variable.

This pull request also includes some edits to David Lapp's Spatial lab 7; more edits will be coming shortly.