### PR TITLE
Workshop ID#141 change "proceed to the next lab" statement to include…

### DIFF
--- a/data-management-library/autonomous-database/shared/adb-loading/adb-loading-conditional.md
+++ b/data-management-library/autonomous-database/shared/adb-loading/adb-loading-conditional.md
@@ -350,7 +350,7 @@ This task shows how to load data from Oracle Cloud Infrastructure Object Storage
 
 5.  To learn more about how to specify file formats, delimiters, reject limits, and more, review the <a href="https://docs.oracle.com/en/cloud/paas/autonomous-data-warehouse-cloud/user/dbmscloud-reference.html" target="\_blank"> Autonomous Database Supplied Package Reference </a> and <a href="https://docs.oracle.com/en/cloud/paas/autonomous-data-warehouse-cloud/user/format-options.html#GUID-08C44CDA-7C81-481A-BA0A-F7346473B703" target="\_blank"> DBMS_CLOUD Package Format Options </a>
 
-Please *proceed to the next lab*.
+You may now [proceed to the next lab](#next).
 
 ## Want to learn more?
 

--- a/data-management-library/autonomous-database/shared/adb-provision/adb-provision-conditional.md
+++ b/data-management-library/autonomous-database/shared/adb-provision/adb-provision-conditional.md
@@ -153,7 +153,7 @@ In this lab, you will:
 
     ![Database instance homepage.](./images/task2-11.png " ")
 
-Please *proceed to the next lab*.
+You may now [proceed to the next lab](#next).
 
 ## Learn More
 

--- a/data-management-library/autonomous-database/shared/adb-query/adb-query.md
+++ b/data-management-library/autonomous-database/shared/adb-query/adb-query.md
@@ -61,7 +61,7 @@ Estimated Time: 10 minutes
 
     ![Paste the code snippet and click Run Script.](images/external_table_query_results.jpg " ")
 
-Please *proceed to the next lab*.
+You may now [proceed to the next lab](#next).
 
 ## Want to learn more?
 

--- a/data-management-library/autonomous-database/shared/adb-sqldevweb/adb-sqldevweb.md
+++ b/data-management-library/autonomous-database/shared/adb-sqldevweb/adb-sqldevweb.md
@@ -84,7 +84,7 @@ Run a query on a sample Oracle Autonomous Database data set.
 
 4.  You can find more sample queries to run <a href="https://docs.oracle.com/en/cloud/paas/autonomous-data-warehouse-cloud/user/sample-queries.html" target="\_blank">in the ADW documentation</a>.
 
-Please *proceed to the next lab*.
+You may now [proceed to the next lab](#next).
 
 ## Want to learn more?
 


### PR DESCRIPTION
… link to next lab

In "Autonomous Database Quick Start" workshop, being used at Database World as "Keith's Guide to Getting Started with Autonomous Database", I changed the "proceed to next lab" statement at the end of Labs 1-4 to provide the link to the next lab:  You may now [proceed to the next lab](#next).