### PR TITLE
Workshop ID#141 "Autonomous Database Quick Start": modify script as workaround to software bug

### DIFF
--- a/data-management-library/autonomous-database/shared/adb-query/files/create_external_tables_without_base_url_v2.txt
+++ b/data-management-library/autonomous-database/shared/adb-query/files/create_external_tables_without_base_url_v2.txt
@@ -1,8 +1,11 @@
 /* Specify the URL that you copied from your files in OCI Object Storage in the define base_URL line below*/
 
 set define on
+/* Specify the URL that you copied from your files in OCI Object Storage in the define base_URL line below*/
+ 
+set define on
 define &file_uri_base = '<bucket URI>'
-
+ 
 begin
  dbms_cloud.create_external_table(
     table_name =>'CHANNELS_EXT',
@@ -10,223 +13,198 @@ begin
     file_uri_list =>'&file_uri_base/chan_v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true'),
     column_list => 'CHANNEL_ID NUMBER,
-	CHANNEL_DESC VARCHAR2(20),
-	CHANNEL_CLASS VARCHAR2(20),
-	CHANNEL_CLASS_ID NUMBER,
-	CHANNEL_TOTAL VARCHAR2(13),
-	CHANNEL_TOTAL_ID NUMBER'
+        CHANNEL_DESC VARCHAR2(20),
+        CHANNEL_CLASS VARCHAR2(20),
+        CHANNEL_CLASS_ID NUMBER,
+        CHANNEL_TOTAL VARCHAR2(13),
+        CHANNEL_TOTAL_ID NUMBER'
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'COUNTRIES_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/coun_v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true'),
     column_list => 'COUNTRY_ID NUMBER ,
-	COUNTRY_ISO_CODE CHAR(2) ,
-	COUNTRY_NAME VARCHAR2(40) ,
-	COUNTRY_SUBREGION VARCHAR2(30) ,
-	COUNTRY_SUBREGION_ID NUMBER ,
-	COUNTRY_REGION VARCHAR2(20) ,
-	COUNTRY_REGION_ID NUMBER ,
-	COUNTRY_TOTAL VARCHAR2(11) ,
-	COUNTRY_TOTAL_ID NUMBER ,
-	COUNTRY_NAME_HIST VARCHAR2(40)'
+        COUNTRY_ISO_CODE CHAR(2) ,
+        COUNTRY_NAME VARCHAR2(40) ,
+        COUNTRY_SUBREGION VARCHAR2(30) ,
+        COUNTRY_SUBREGION_ID NUMBER ,
+        COUNTRY_REGION VARCHAR2(20) ,
+        COUNTRY_REGION_ID NUMBER ,
+        COUNTRY_TOTAL VARCHAR2(11) ,
+        COUNTRY_TOTAL_ID NUMBER ,
+        COUNTRY_NAME_HIST VARCHAR2(40)'
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'CUSTOMERS_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/cust1v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true', 'dateformat' value 'YYYY-MM-DD-HH24-MI-SS'),
     column_list => 'CUST_ID NUMBER ,
-	CUST_FIRST_NAME VARCHAR2(20) ,
-	CUST_LAST_NAME VARCHAR2(40) ,
-	CUST_GENDER CHAR(1) ,
-	CUST_YEAR_OF_BIRTH NUMBER(4,0) ,
-	CUST_MARITAL_STATUS VARCHAR2(20),
-	CUST_STREET_ADDRESS VARCHAR2(40) ,
-	CUST_POSTAL_CODE VARCHAR2(10) ,
-	CUST_CITY VARCHAR2(30) ,
-	CUST_CITY_ID NUMBER ,
-	CUST_STATE_PROVINCE VARCHAR2(40) ,
-	CUST_STATE_PROVINCE_ID NUMBER ,
-	COUNTRY_ID NUMBER ,
-	CUST_MAIN_PHONE_NUMBER VARCHAR2(25) ,
-	CUST_INCOME_LEVEL VARCHAR2(30),
-	CUST_CREDIT_LIMIT NUMBER,
-	CUST_EMAIL VARCHAR2(50),
-	CUST_TOTAL VARCHAR2(14) ,
-	CUST_TOTAL_ID NUMBER ,
-	CUST_SRC_ID NUMBER,
-	CUST_EFF_FROM DATE,
-	CUST_EFF_TO DATE,
-	CUST_VALID VARCHAR2(1)'
+        CUST_FIRST_NAME VARCHAR2(20) ,
+        CUST_LAST_NAME VARCHAR2(40) ,
+        CUST_GENDER CHAR(1) ,
+        CUST_YEAR_OF_BIRTH NUMBER(4,0) ,
+        CUST_MARITAL_STATUS VARCHAR2(20),
+        CUST_STREET_ADDRESS VARCHAR2(40) ,
+        CUST_POSTAL_CODE VARCHAR2(10) ,
+        CUST_CITY VARCHAR2(30) ,
+        CUST_CITY_ID NUMBER ,
+        CUST_STATE_PROVINCE VARCHAR2(40) ,
+        CUST_STATE_PROVINCE_ID NUMBER ,
+        COUNTRY_ID NUMBER ,
+        CUST_MAIN_PHONE_NUMBER VARCHAR2(25) ,
+        CUST_INCOME_LEVEL VARCHAR2(30),
+        CUST_CREDIT_LIMIT NUMBER,
+        CUST_EMAIL VARCHAR2(50),
+        CUST_TOTAL VARCHAR2(14) ,
+        CUST_TOTAL_ID NUMBER ,
+        CUST_SRC_ID NUMBER,
+        CUST_EFF_FROM DATE,
+        CUST_EFF_TO DATE,
+        CUST_VALID VARCHAR2(1)'
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'SUPPLEMENTARY_DEMOGRAPHICS_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/dem1v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true'),
     column_list => 'CUST_ID NUMBER ,
-	EDUCATION VARCHAR2(21),
-	OCCUPATION VARCHAR2(21),
-	HOUSEHOLD_SIZE VARCHAR2(21),
-	YRS_RESIDENCE NUMBER,
-	AFFINITY_CARD NUMBER(10,0),
-	BULK_PACK_DISKETTES NUMBER(10,0),
-	FLAT_PANEL_MONITOR NUMBER(10,0),
-	HOME_THEATER_PACKAGE NUMBER(10,0),
-	BOOKKEEPING_APPLICATION NUMBER(10,0),
-	PRINTER_SUPPLIES NUMBER(10,0),
-	Y_BOX_GAMES NUMBER(10,0),
-	OS_DOC_SET_KANJI NUMBER(10,0),
-	COMMENTS VARCHAR2(4000)'
+        EDUCATION VARCHAR2(21),
+        OCCUPATION VARCHAR2(21),
+        HOUSEHOLD_SIZE VARCHAR2(21),
+        YRS_RESIDENCE NUMBER,
+        AFFINITY_CARD NUMBER(10,0),
+        BULK_PACK_DISKETTES NUMBER(10,0),
+        FLAT_PANEL_MONITOR NUMBER(10,0),
+        HOME_THEATER_PACKAGE NUMBER(10,0),
+        BOOKKEEPING_APPLICATION NUMBER(10,0),
+        PRINTER_SUPPLIES NUMBER(10,0),
+        Y_BOX_GAMES NUMBER(10,0),
+        OS_DOC_SET_KANJI NUMBER(10,0),
+        COMMENTS VARCHAR2(4000)'
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'PRODUCTS_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/prod1v3.dat',
     format => json_object('delimiter' value '|', 'quote' value '^', 'ignoremissingcolumns' value 'true', 'dateformat' value 'YYYY-MM-DD-HH24-MI-SS', 'blankasnull' value 'true'),
     column_list => 'PROD_ID NUMBER(6,0) ,
-	PROD_NAME VARCHAR2(50) ,
-	PROD_DESC VARCHAR2(4000) ,
-	PROD_SUBCATEGORY VARCHAR2(50) ,
-	PROD_SUBCATEGORY_ID NUMBER ,
-	PROD_SUBCATEGORY_DESC VARCHAR2(2000) ,
-	PROD_CATEGORY VARCHAR2(50) ,
-	PROD_CATEGORY_ID NUMBER ,
-	PROD_CATEGORY_DESC VARCHAR2(2000) ,
-	PROD_WEIGHT_CLASS NUMBER(3,0) ,
-	PROD_UNIT_OF_MEASURE VARCHAR2(20),
-	PROD_PACK_SIZE VARCHAR2(30) ,
-	SUPPLIER_ID NUMBER(6,0) ,
-	PROD_STATUS VARCHAR2(20) ,
-	PROD_LIST_PRICE NUMBER(8,2) ,
-	PROD_MIN_PRICE NUMBER(8,2) ,
-	PROD_TOTAL VARCHAR2(13) ,
-	PROD_TOTAL_ID NUMBER ,
-	PROD_SRC_ID NUMBER,
-	PROD_EFF_FROM DATE,
-	PROD_EFF_TO DATE,
-	PROD_VALID VARCHAR2(1)'
+        PROD_NAME VARCHAR2(50) ,
+        PROD_DESC VARCHAR2(4000) ,
+        PROD_SUBCATEGORY VARCHAR2(50) ,
+        PROD_SUBCATEGORY_ID NUMBER ,
+        PROD_SUBCATEGORY_DESC VARCHAR2(2000) ,
+        PROD_CATEGORY VARCHAR2(50) ,
+        PROD_CATEGORY_ID NUMBER ,
+        PROD_CATEGORY_DESC VARCHAR2(2000) ,
+        PROD_WEIGHT_CLASS NUMBER(3,0) ,
+        PROD_UNIT_OF_MEASURE VARCHAR2(20),
+        PROD_PACK_SIZE VARCHAR2(30) ,
+        SUPPLIER_ID NUMBER(6,0) ,
+        PROD_STATUS VARCHAR2(20) ,
+        PROD_LIST_PRICE NUMBER(8,2) ,
+        PROD_MIN_PRICE NUMBER(8,2) ,
+        PROD_TOTAL VARCHAR2(13) ,
+        PROD_TOTAL_ID NUMBER ,
+        PROD_SRC_ID NUMBER,
+        PROD_EFF_FROM DATE,
+        PROD_EFF_TO DATE,
+        PROD_VALID VARCHAR2(1)'
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'PROMOTIONS_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/prom1v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true', 'dateformat' value 'YYYY-MM-DD-HH24-MI-SS', 'blankasnull' value 'true'),
     column_list => 'PROMO_ID NUMBER(6,0) ,
-	PROMO_NAME VARCHAR2(30) ,
-	PROMO_SUBCATEGORY VARCHAR2(30) ,
-	PROMO_SUBCATEGORY_ID NUMBER ,
-	PROMO_CATEGORY VARCHAR2(30) ,
-	PROMO_CATEGORY_ID NUMBER ,
-	PROMO_COST NUMBER(10,2) ,
-	PROMO_BEGIN_DATE DATE ,
-	PROMO_END_DATE DATE ,
-	PROMO_TOTAL VARCHAR2(15) ,
-	PROMO_TOTAL_ID NUMBER '
+        PROMO_NAME VARCHAR2(30) ,
+        PROMO_SUBCATEGORY VARCHAR2(30) ,
+        PROMO_SUBCATEGORY_ID NUMBER ,
+        PROMO_CATEGORY VARCHAR2(30) ,
+        PROMO_CATEGORY_ID NUMBER ,
+        PROMO_COST NUMBER(10,2) ,
+        PROMO_BEGIN_DATE DATE ,
+        PROMO_END_DATE DATE ,
+        PROMO_TOTAL VARCHAR2(15) ,
+        PROMO_TOTAL_ID NUMBER '
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'SALES_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/sale1v3.dat,&file_uri_base/dmsal_v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true', 'dateformat' value 'YYYY-MM-DD', 'blankasnull' value 'true'),
     column_list => 'PROD_ID NUMBER ,
-	CUST_ID NUMBER ,
-	TIME_ID DATE ,
-	CHANNEL_ID NUMBER ,
-	PROMO_ID NUMBER ,
-	QUANTITY_SOLD NUMBER(10,2) ,
-	AMOUNT_SOLD NUMBER(10,2)'
+        CUST_ID NUMBER ,
+        TIME_ID DATE ,
+        CHANNEL_ID NUMBER ,
+        PROMO_ID NUMBER ,
+        QUANTITY_SOLD NUMBER(10,2) ,
+        AMOUNT_SOLD NUMBER(10,2)'
  );
-end;
-/
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'TIMES_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/time_v3.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'removequotes' value 'true', 'dateformat' value 'YYYY-MM-DD-HH24-MI-SS', 'blankasnull' value 'true'),
     column_list => 'TIME_ID DATE ,
-	DAY_NAME VARCHAR2(9) ,
-	DAY_NUMBER_IN_WEEK NUMBER(1,0) ,
-	DAY_NUMBER_IN_MONTH NUMBER(2,0) ,
-	CALENDAR_WEEK_NUMBER NUMBER(2,0) ,
-	FISCAL_WEEK_NUMBER NUMBER(2,0) ,
-	WEEK_ENDING_DAY DATE ,
-	WEEK_ENDING_DAY_ID NUMBER ,
-	CALENDAR_MONTH_NUMBER NUMBER(2,0) ,
-	FISCAL_MONTH_NUMBER NUMBER(2,0) ,
-	CALENDAR_MONTH_DESC VARCHAR2(8) ,
-	CALENDAR_MONTH_ID NUMBER ,
-	FISCAL_MONTH_DESC VARCHAR2(8) ,
-	FISCAL_MONTH_ID NUMBER ,
-	DAYS_IN_CAL_MONTH NUMBER ,
-	DAYS_IN_FIS_MONTH NUMBER ,
-	END_OF_CAL_MONTH DATE ,
-	END_OF_FIS_MONTH DATE ,
-	CALENDAR_MONTH_NAME VARCHAR2(9) ,
-	FISCAL_MONTH_NAME VARCHAR2(9) ,
-	CALENDAR_QUARTER_DESC CHAR(7) ,
-	CALENDAR_QUARTER_ID NUMBER ,
-	FISCAL_QUARTER_DESC CHAR(7) ,
-	FISCAL_QUARTER_ID NUMBER ,
-	DAYS_IN_CAL_QUARTER NUMBER ,
-	DAYS_IN_FIS_QUARTER NUMBER ,
-	END_OF_CAL_QUARTER DATE ,
-	END_OF_FIS_QUARTER DATE ,
-	CALENDAR_QUARTER_NUMBER NUMBER(1,0) ,
-	FISCAL_QUARTER_NUMBER NUMBER(1,0) ,
-	CALENDAR_YEAR NUMBER(4,0) ,
-	CALENDAR_YEAR_ID NUMBER ,
-	FISCAL_YEAR NUMBER(4,0) ,
-	FISCAL_YEAR_ID NUMBER ,
-	DAYS_IN_CAL_YEAR NUMBER ,
-	DAYS_IN_FIS_YEAR NUMBER ,
-	END_OF_CAL_YEAR DATE ,
-	END_OF_FIS_YEAR DATE '
+        DAY_NAME VARCHAR2(9) ,
+        DAY_NUMBER_IN_WEEK NUMBER(1,0) ,
+        DAY_NUMBER_IN_MONTH NUMBER(2,0) ,
+        CALENDAR_WEEK_NUMBER NUMBER(2,0) ,
+        FISCAL_WEEK_NUMBER NUMBER(2,0) ,
+        WEEK_ENDING_DAY DATE ,
+        WEEK_ENDING_DAY_ID NUMBER ,
+        CALENDAR_MONTH_NUMBER NUMBER(2,0) ,
+        FISCAL_MONTH_NUMBER NUMBER(2,0) ,
+        CALENDAR_MONTH_DESC VARCHAR2(8) ,
+        CALENDAR_MONTH_ID NUMBER ,
+        FISCAL_MONTH_DESC VARCHAR2(8) ,
+        FISCAL_MONTH_ID NUMBER ,
+        DAYS_IN_CAL_MONTH NUMBER ,
+        DAYS_IN_FIS_MONTH NUMBER ,
+        END_OF_CAL_MONTH DATE ,
+        END_OF_FIS_MONTH DATE ,
+        CALENDAR_MONTH_NAME VARCHAR2(9) ,
+        FISCAL_MONTH_NAME VARCHAR2(9) ,
+        CALENDAR_QUARTER_DESC CHAR(7) ,
+        CALENDAR_QUARTER_ID NUMBER ,
+        FISCAL_QUARTER_DESC CHAR(7) ,
+        FISCAL_QUARTER_ID NUMBER ,
+        DAYS_IN_CAL_QUARTER NUMBER ,
+        DAYS_IN_FIS_QUARTER NUMBER ,
+        END_OF_CAL_QUARTER DATE ,
+        END_OF_FIS_QUARTER DATE ,
+        CALENDAR_QUARTER_NUMBER NUMBER(1,0) ,
+        FISCAL_QUARTER_NUMBER NUMBER(1,0) ,
+        CALENDAR_YEAR NUMBER(4,0) ,
+        CALENDAR_YEAR_ID NUMBER ,
+        FISCAL_YEAR NUMBER(4,0) ,
+        FISCAL_YEAR_ID NUMBER ,
+        DAYS_IN_CAL_YEAR NUMBER ,
+        DAYS_IN_FIS_YEAR NUMBER ,
+        END_OF_CAL_YEAR DATE ,
+        END_OF_FIS_YEAR DATE '
  );
-end;
-/
-
-
-begin
+ 
  dbms_cloud.create_external_table(
     table_name =>'COSTS_EXT',
     credential_name =>'OBJ_STORE_CRED',
     file_uri_list =>'&file_uri_base/costs.dat',
     format => json_object('ignoremissingcolumns' value 'true', 'dateformat' value 'YYYY-MM-DD', 'blankasnull' value 'true'),
     column_list => 'PROD_ID NUMBER ,
-	TIME_ID DATE ,
-	PROMO_ID NUMBER ,
-	CHANNEL_ID NUMBER ,
-	UNIT_COST NUMBER(10,2) ,
-	UNIT_PRICE NUMBER(10,2) '
+        TIME_ID DATE ,
+        PROMO_ID NUMBER ,
+        CHANNEL_ID NUMBER ,
+        UNIT_COST NUMBER(10,2) ,
+        UNIT_PRICE NUMBER(10,2) '
  );
 end;
 /

--- a/data-management-library/database/multitenant/README.md
+++ b/data-management-library/database/multitenant/README.md
@@ -5,7 +5,7 @@ Oracle Multitenant is the architecture for the next-generation database cloud. I
 ## Workshops
 [Run a workshop now!](https://apexapps.oracle.com/pls/apex/dbpm/r/livelabs/view-workshop?p180_id=573)
 
-## Get an Oracle Cloud Trial Account for Free!
+## Get an Oracle Cloud Trial Account for Free
 If you don't have an Oracle Cloud account then you can quickly and easily sign up for a free trial account that provides:
 - $300 of free credits good for up to 3500 hours of Oracle Cloud usage
 - Credits can be used on all eligible Cloud Platform and Infrastructure services for the next 30 days
@@ -31,4 +31,3 @@ Click here to request your trial account: [https://www.oracle.com/cloud/free](ht
 - [Converged Database Architcture](https://www.youtube.com/watch?v=9d76-LhgMQs)
 - [Multitenant PDBs for Microservices and Clouds](https://www.youtube.com/watch?v=JdfATqdXuRc)
 - [The Hidden Data Economy](https://www.youtube.com/watch?v=CP3pwAwNepU)
-

--- a/data-management-library/database/multitenant/app-containers/app-containers.md
+++ b/data-management-library/database/multitenant/app-containers/app-containers.md
@@ -1,23 +1,23 @@
-# Application Containers #
+# Application containers
 
 ## Introduction
-This is a series of 12 hands-on labs designed to familiarize you with the Application Container functionality of Oracle Multitenant. In these labs, we follow the journey of a notional company, Walt’s Malts, as their business expands from a single store to a global powerhouse – “from startup to starship”.
+This is a series of 12 hands-on labs designed to familiarize you with the Application Container functionality of Oracle Multitenant. In these labs, we follow the journey of a notional company, Walt’s Malts, as their business expands from a single store to a global powerhouse, “from startup to starship”.
 
-*Estimated Workshop Time*: 1 hour
+Estimated Time: 1 hour
 
 [](youtube:ZPOjjF3kCvo)
 
 ### Prerequisites
 This lab assumes you have:
 - A Free Tier, Paid or LiveLabs Oracle Cloud account
-- SSH Private Key to access the host via SSH
+- SSH Private Key to access the host using SSH
 - You have completed:
     - Lab: Generate SSH Keys (*Free-tier* and *Paid Tenants* only)
     - Lab: Prepare Setup (*Free-tier* and *Paid Tenants* only)
     - Lab: Environment Setup
     - Lab: Clone, Plug and Drop
 
-## Task 0: Connect to Your Instance and Login
+## Task 0: Connect to your instance and log in
 
 This Lab assumes that you have already Initialized your environment as instructed in "*Lab: Clone, Plug and Drop*". If you haven't please return to that lab and execute "*Step 0*" at the minimum.
 
@@ -43,13 +43,13 @@ This Lab assumes that you have already Initialized your environment as instructe
 ## Task 1: Instant SaaS
 This section shows how Multitenant with Application Containers provides an instant SaaS architecture for an application formerly architected for standalone deployment.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Setup Application Root - wmStore_Master
 - Install v1 of Application wmStore in Application Root
 - Create and sync Application Seed and provision Application PDBs for four franchises: Tulsa, California, Tahoe, NYC
 - Populate Application Tenant PDBs with demo data.
 
-In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Command Line (SQLcl).  Oracle **SQLcl** is the modern, command-line interface to the database.  **SQLcl** has many key features that add to the value of the utility, including command history, in-line editing, auto-complete using the TAB key and more.  You can learn more about **SQLcl** [here](https://www.oracle.com/database/technologies/appdev/sqlcl.html).
+In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Command Line (SQLcl).  Oracle **SQLcl** is the modern, command line interface to the database. **SQLcl** has many key features that add to the value of the utility, including command history, in-line editing, auto complete using the TAB key and more. You can learn more about **SQLcl** [at the Oracle SQLcl website](https://www.oracle.com/database/technologies/appdev/sqlcl.html).
 
 
 1. Start SQLcl, set the sqlformat for easier on-screen viewing, and connect to **CDB1**.
@@ -251,7 +251,7 @@ In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Co
 
     ![](./images/task1.3.4-insertvalues.png " ")
 
-4. Create the application seed PDB, which will be used to create additional application PDBs.  Open the application seed PDB after it is created.
+4. Create the application seed PDB, which will be used to create additional application PDBs. Open the application seed PDB after it is created.
 
     ```
     <copy>conn system/oracle@localhost:1523/wmStore_Master;</copy>
@@ -311,7 +311,7 @@ In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Co
 
     ![](./images/task1.6-createapppdb.png " ")
 
-7. Create franchise-specific data by running the supplied script.  In SQLcl we'll use the "cd" command to execute scripts from the correct directory.
+7. Create franchise-specific data by running the supplied script. In SQLcl we'll use the "cd" command to execute scripts from the correct directory.
 
     ```
     <copy>conn system/oracle@localhost:1523/wmStore_Master;</copy>
@@ -329,10 +329,10 @@ In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Co
 
     ![](./images/task1.7-createfranchise2.png " ")
 
-## Task 2: PDB Exploration
+## Task 2: PDB exploration
 In this section you will take a brief tour of the newly created SaaS estate.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Look at the PDBs that have been created so far
 - Experiment with different classes of User
 - Perform queries against different franchises
@@ -408,7 +408,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task2.4-cannotusetulsa.png " ")
 
-5. Now you'll explore the data inside the application PDBs using some sample queries.  Note that each store has its own products, sales campaigns, and order quantities. First you'll create a script to query each franchise's sales by product by campaign
+5. Now you'll explore the data inside the application PDBs using some sample queries. Note that each store has its own products, sales campaigns, and order quantities. First you'll create a script to query each franchise's sales by product by campaign
 
     ```
     <copy>
@@ -462,9 +462,9 @@ The tasks you will accomplish in this step are:
 In this section you have observed how each application PDB has its own data through queries directly against each application PDB.  In an upcoming lab, you will learn how to run queries from the Application Root across multiple Application Tenant PDBs.
 
 ## Task 3: Upgrade from v1 to v2
-In this section we'll upgrade Application wmStore from v1 to v2. Despite each franchise having a separate tenant PDB, there is only one master application definition to be upgraded – in the Application Root. We run the upgrade script only once, against the Application Root. It is then simply a matter of synchronizing the tenant PDBs for each franchise for them to be upgraded to the new version. Note that this model allows for granular (per tenant/franchise) upgrade schedules.
+In this section we'll upgrade Application wmStore from v1 to v2. Despite each franchise having a separate tenant PDB, there is only one master application definition to be upgraded, in the Application Root. We run the upgrade script only once, against the Application Root. It is then simply a matter of synchronizing the tenant PDBs for each franchise for them to be upgraded to the new version. Note that this model allows for granular (per tenant/franchise) upgrade schedules.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Upgrade application wmStore to v2
 - Synchronize three of four Application Tenant PDBs
 
@@ -623,10 +623,10 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task3.5-looknotupgradepdb.png " ")
 
-## Task 4: Containers Queries
-In this section we introduce a very powerful cross-container aggregation capability: **containers()** queries. Containers() queries allow an application administrator to connect to the Application Root and aggregate data with a single query across some or all Application Tenants (Franchises). This is another example of how Multitenant, with Application Containers, allows you to manage many Application Tenants as one, when needed. Notice values in the column Franchise come from Con$Name. Remember that containers() queries are executed in Root and all containers plugged into it.
+## Task 4: Containers queries
+In this section we introduce a very powerful cross-container aggregation capability: **containers()** queries. Containers() queries enable an application administrator to connect to the Application Root and aggregate data with a single query across some or all Application Tenants (Franchises). This is another example of how Multitenant, with Application Containers, enables you to manage many Application Tenants as one, when needed. Notice values in the column Franchise come from Con$Name. Remember that containers() queries are executed in Root and all containers plugged into it.
 
-The tasks you will accomplish in this step are:
+The task you will do in this step is:
 - Run Queries across containers
 
 1. Connect to the Application Master PDB as the application administrator.
@@ -681,7 +681,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task4.4-ordervolume.png " ")
 
-## Task 5: Application Compatibility
+## Task 5: Application compatibility
 In this section you will explore the PDBs and learn how to set compatibility at the Application Master.
 
 1. Connect to ``CDB1``.
@@ -783,13 +783,13 @@ In this section you will explore the PDBs and learn how to set compatibility at 
 
 
 
-## Task 6: Expansion Beyond Single CDB and Application Root Replicas
-In this section we follow the global expansion of Walt's Malts. In order to comply with requirements of data sovereignty and latency Walt's Malts has had to expand into a second CDB, CDB2. (In reality this would be in a separate server.) It is very important to note that we still only have a single master application definition, despite the application now being deployed across multiple CDBs.
+## Task 6: Expansion beyond single CDB and application root replicas
+In this section we follow the global expansion of Walt's Malts. To comply with requirements of data sovereignty and latency, Walt's Malts has had to expand into a second CDB, CDB2. (In reality this would be in a separate server.) It is very important to note that we still only have a single master application definition, despite the application now being deployed across multiple CDBs.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Create and Open Application Root Replicas (ARRs): wmStore_International, wmStore_West
 - Create Proxy PDBs for the ARRs
-- Synchronize the ARRs via their proxies
+- Synchronize the ARRs by using their proxies
 - Create App Seeds for the ARRs
 - Provision the App PDBs for five new franchises
 - Add franchise-specific products for new franchises
@@ -837,7 +837,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task6.3-openarrs.png " ")
 
-4. Since the databases in CDB2 register with a listener with a non-default port (in this case, port 1524) you will need to update the ARRs with that port information.  This is critical, since the proxy PDBs you will create require this configuration in order to communicate with their target PDBs.
+4. Since the databases in CDB2 register with a listener with a non-default port (in this case, port 1524) you will need to update the ARRs with that port information. This is critical, since the proxy PDBs you will create require this configuration in order to communicate with their target PDBs.
 
     ```
     <copy>connect system/oracle@localhost:1524/wmStore_International</copy>
@@ -913,7 +913,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task6.7-openproxypdb.png " ")
 
-8. Synchronize the Application Root Replicas (ARRs) via their proxies.
+8. Synchronize the Application Root Replicas (ARRs) by using their proxies.
 
     ```
     <copy>conn system/oracle@localhost:1523/wmStore_International_Proxy</copy>
@@ -1048,7 +1048,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task6.14-provisionfranchise.png " ")
 
-15. Switch to the container root and open all of the pluggable databases.
+15. Switch to the container root and open all pluggable databases.
 
     ```
     <copy>alter session set container=CDB$Root;</copy>
@@ -1068,7 +1068,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task6.16-franchisedata.png " ")
 
-17. Connect to wmStore_Master and run a report of orders by franchise.  Note the results include the stores who's application PDBs reside in **CDB2**; these are accessed via the Proxy PDBs that were created in **CDB1**.
+17. Connect to wmStore_Master and run a report of orders by franchise. Note the results include the stores who's application PDBs reside in **CDB2**; these are accessed through the Proxy PDBs that were created in **CDB1**.
 
     ```
     <copy>connect wmStore_Admin/oracle@localhost:1523/wmStore_Master</copy>
@@ -1095,10 +1095,10 @@ The tasks you will accomplish in this step are:
 
 
 
-## Task 7: Durable Location Transparency
-This lab task demonstrates "durable location transparency". In the previous section we saw how Proxy PDBs can provide location transparency, allowing us to access remote application PDBs from the local Application Root. The Proxy PDBs for the Application Root Replicas (ARRs) provided local context (in the master Application Root) for the ARRs, which are physically located in a different CDB. This is a good example of location transparency. In this section, we see how these ARR Proxies can provide "durable location transparency". That is, location transparency that survives the physical reconfiguration of the Application Estate – specifically by relocating an Application PDB for a particular franchise from one CDB to another.
+## Task 7: Durable location transparency
+This lab task demonstrates "durable location transparency." In the previous section we saw how Proxy PDBs can provide location transparency, allowing us to access remote application PDBs from the local Application Root. The Proxy PDBs for the Application Root Replicas (ARRs) provided local context (in the master Application Root) for the ARRs, which are physically located in a different CDB. This is a good example of location transparency. In this section, we see how these ARR Proxies can provide "durable location transparency." That is, location transparency that survives the physical reconfiguration of the Application Estate – specifically by relocating an Application PDB for a particular franchise from one CDB to another.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Run a report against wmStore_Master
 - Relocate Tahoe to wmStore_West
 - Run the report again
@@ -1159,12 +1159,12 @@ The tasks you will accomplish in this step are:
 
 Although we physically relocated an application PDB from one CDB to another, that move was transparent to our reporting application.
 
-## Task 8: Data Sharing
+## Task 8: Data sharing
 In this section we introduce the advanced concept of data sharing. We have already seen how Multitenant, with Application Containers, can provide an instant SaaS architecture for an application previously architected for standalone deployment. Technically this is done by installing a master application definition in an Application Root. Application PDBs for each tenant / franchise are plugged into this Application Root and the metadata for the database components of the Application definition is served from the Application root. Up to this point, all data - including data which may be considered part of the application definition "seed data" - has been local. In other words, there's a replica of this seed data in every Application PDB.
 
 In this lab we'll see how, in addition to metadata, common data may also be shared from Application Root. To do this we'll upgrade application wmStore to v3.0 and introduce various powerful data sharing capabilities.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Upgrade Application wmStore to v3.0
 - Propagate the Upgrade to all franchises
 - Query the wm_Products table in a franchise PDB to see the sources of data
@@ -1284,7 +1284,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task8.1-createupgrade4.png " ")
 
-2. Sync some of the pluggable databases.
+2. Sync some pluggable databases.
 
     ```
     <copy>
@@ -1383,7 +1383,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task8.4-querymaster.png " ")
 
-5. Query against the container Tulsa.  Note all the data is visible but some data is being shared from the application master.
+5. Query against the container Tulsa. Note all the data is visible but some data is being shared from the application master.
 
     ```
     <copy>connect wmStore_Admin/oracle@localhost:1523/Tulsa</copy>
@@ -1401,15 +1401,15 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task8.5-querytulsa.png " ")
 
-## Task 9: Application Patches
+## Task 9: Application patches
 In this task we define an application patch. Patches are comparable to the application upgrades that we've seen in previous labs, but there are three important differences.
 - The types of operations that are allowed in a patch are more limited. Operations which are destructive are not allowed within a patch, including:
-    - Drop a table, column, index, trigger...
-    - create or replace view, package, procedure...
+    - Drop a table, column, index, trigger, and others.
+    - Create or replace view, package, procedure, and others.
 - Patches do not involve creation of Application Root Clones.
 - Patches are not version-specific. This means that a single patch may be applied to multiple application versions.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Define patch 301 for application wmStore
 - Propagate the patch to the Application Root Replicas. Then apply it to three franchises (but not to all)
 
@@ -1524,7 +1524,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task9.1-createpatch2.png " ")
 
-2. Apply the patch to some but not all of the databases.
+2. Apply the patch to some but not all databases.
 
     ```
     <copy>
@@ -1540,10 +1540,10 @@ The tasks you will accomplish in this step are:
     ```
     ![](./images/task9.2-applypatch.png " ")
 
-## Task 10: DBA Views
-This section we introduce some of the DBA Views which are relevant to Application Containers.
+## Task 10: DBA views
+This section we introduce some DBA Views which are relevant to Application Containers.
 
-The tasks you will accomplish in this step are:
+The task you will do in this step is:
 - Explore various DBA Views as they relate to Application Containers
 
 1. DBA_PDBs
@@ -1679,11 +1679,11 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task10.7-dba_app_errors.png " ")
 
-## Task 11: Diagnosing and Correcting Problems, Restarting Sync
+## Task 11: Diagnosing and correcting problems, restarting sync
 This section will explore the ability to restart the patching process after diagnosing errors.
 
-The tasks you will accomplish in this step are:
-- Deliberately make a manual change to NYC that will conflict with applying patch 301
+The tasks you will do in this step are:
+- Make a manual change to NYC that will intentionally conflict with applying patch 301
 - Attempt to sync NYC to apply the patch - anticipating failure
 - Query relevant DBA views to identify the problem
 - Resolve the problem and restart the sync, which should now succeed.
@@ -1737,10 +1737,10 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task11.4-syncsuccess.png " ")
 
-## Task 12: Container Map
+## Task 12: Container map
 This section we explore another location transparency technology: Container Map. Here we follow the expansion of Walt's Malts through the acquisition of a formerly independent distributor of Walt's Malts products. This company is named Terminally Chill, and their niche was selling Walt's Malts products through a number of small kiosks in various airports globally. The Terminally Chill application has a different design from the original wmStore application. Whereas wmStore was originally designed for standalone deployment, Terminally Chill used a single database to manage data for all kiosks in all airports. The application server tiers are designed to connect directly to a single database, with query predicates to retrieve data for the right airport and kiosk. In this lab, we'll see how Container Map can help accommodate applications of this design.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Setup Application PDBs for new Airport franchises
 - Install v1 of Application "Terminal"
 - Sync Application PDBs

--- a/data-management-library/database/multitenant/clone-plug-drop/clone-plug-drop.md
+++ b/data-management-library/database/multitenant/clone-plug-drop/clone-plug-drop.md
@@ -1,9 +1,9 @@
-# Clone, Plug and Drop
+# Clone, plug and drop
 
 ## Introduction
-In this lab you will perform many multitenant basic tasks.  You will create a pluggable database (PDB), make a copy of this pluggable database, or clone it, explore the concepts of "plugging" and "unplugging" a PDB and finally drop it.  You will then explore the concepts of cloning unplugged databases and databases that are hot or active.
+In this lab you will perform many multitenant basic tasks. You will create a pluggable database (PDB), make a copy of this pluggable database, or clone it, explore the concepts of "plugging" and "unplugging" a PDB and finally drop it. You will then explore the concepts of cloning unplugged databases and databases that are hot or active.
 
-*Estimated Workshop Time*: 1 hour
+Estimated Time: 1 hour
 
 [](youtube:kzTQGs75IjA)
 
@@ -11,17 +11,17 @@ In this lab you will perform many multitenant basic tasks.  You will create a pl
 
 This lab assumes you have:
 - A Free Tier, Paid or LiveLabs Oracle Cloud account
-- SSH Private Key to access the host via SSH
+- SSH Private Key to access the host using SSH
 - You have completed:
     - Lab: Generate SSH Keys (*Free Tier* and *Paid Tenancies* only)
     - Lab: Prepare Setup (*Free Tier* and *Paid Tenancies* only)
     - Lab: Environment Setup
 
 
-## Task 0: Initialize Environment
+## Task 0: Initialize environment
 Proceed as indicated below to Initialize your workshop instance prior to executing any subsequent step or lab.
 
-Refer to *Lab Environment Setup* for the detailed instructions relevant to your SSH client type (e.g. Putty on Windows or Native such as terminal on Mac OS):
+Refer to *Lab Environment Setup* for the detailed instructions relevant to your SSH client type (such as Putty on Windows or Native such as terminal on Mac OS):
   - Authentication OS User - “*opc*”
   - Authentication method - *SSH RSA Key*
 
@@ -56,8 +56,8 @@ Refer to *Lab Environment Setup* for the detailed instructions relevant to your 
     </copy>
     ```
 
-## Task 1: Login and Create PDB
-In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Command Line (SQLcl).  Oracle **SQLcl** is the modern, command-line interface to the database.  **SQLcl** has many key features that add to the value of the utility, including command history, in-line editing, auto-complete using the TAB key and more.  You can learn more about **SQLcl** [here](https://www.oracle.com/database/technologies/appdev/sqlcl.html).
+## Task 1: Log in and create PDB
+In the following labs, instead of SQL\*Plus you will use Oracle SQL Developer Command Line (SQLcl).  Oracle **SQLcl** is the modern, command line interface to the database. **SQLcl** has many key features that add to the value of the utility, including command history, in-line editing, auto-complete using the TAB key and more. You can learn more about **SQLcl** [at the Oracl SQLcl website](https://www.oracle.com/database/technologies/appdev/sqlcl.html).
 
 In this first task, you will create and explore a new pluggable database **PDB2** in the container database **CDB1**
 
@@ -94,7 +94,7 @@ In this first task, you will create and explore a new pluggable database **PDB2*
     ![](./images/task1.2-connectcdb1.png " ")
 
 
-3. Create a script to check to see who you are connected as. At any point in the lab you can run this script to see who or where you are connected.  We'll save this script for future use and call it "whoami.sql".
+3. Create a script to check to see who you are connected as. At any point in the lab you can run this script to see who or where you are connected. We'll save this script for future use and call it "whoami.sql".
 
     ```
     <copy>
@@ -220,7 +220,7 @@ In this first task, you will create and explore a new pluggable database **PDB2*
 ## Task 2: Clone a PDB
 This lab covers the basics of how to clone a Pluggable Database (PDB).
 
-The tasks you will accomplish in this step are:
+The task you will do in this step is:
 - Clone a pluggable database **PDB2** into **PDB3**
 
 If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
@@ -291,10 +291,10 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 ## Task 3: Unplug a PDB
 This section reviews how to unplug a PDB from its container database (CDB) and save the PDB metadata into an XML manifest file.
 
-The tasks you will accomplish in this step are:
+The task you will do in this step is:
 - Unplug **PDB3** from **CDB1**
 
-If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
+If you are not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
 
     ```
     <copy>sql /nolog
@@ -378,10 +378,10 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 ## Task 4: Plug in a PDB
 This section looks at how to plug in a PDB.
 
-The tasks you will accomplish in this step are:
-- Plug the previously-unplugged **PDB3** into **CDB2**
+The task you will do in this step is:
+- Plug the previously unplugged **PDB3** into **CDB2**
 
-If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
+If you are not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
 
     ```
     <copy>sql /nolog
@@ -487,10 +487,10 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 ## Task 5: Drop a PDB
 This section looks at how to drop a pluggable database.
 
-The tasks you will accomplish in this step are:
+The task you will do in this step is:
 - Drop **PDB3** from **CDB2**
 
-If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
+If you are not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
 
     ```
     <copy>sql /nolog
@@ -525,14 +525,14 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
     ![](./images/task5.2-droppdb3.png " ")
 
 
-## Task 6: Clone an Unplugged PDB
+## Task 6: Clone an unplugged PDB
 This section looks at how to create a gold copy of a PDB and clone it into another container.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Create a gold copy of **PDB2** in **CDB1** as **GOLDPDB**
 - Clone **GOLDPDB** into **COPYPDB1** and **COPYPDB2** in **CDB2**
 
-If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
+If you are not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
 
     ```
     <copy>sql /nolog
@@ -615,7 +615,7 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
     ![](./images/task6.6-dropgoldpdb.png " ")
 
-7. We want to clone our gold image PDB into another container database.  Connect to **CDB2** and validate **GOLDPDB** is compatible with **CDB2**.
+7. We want to clone our gold image PDB into another container database. Connect to **CDB2** and validate **GOLDPDB** is compatible with **CDB2**.
 
     ```
     <copy>connect sys/oracle@localhost:1524/cdb2 as sysdba</copy>
@@ -671,7 +671,7 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
     ![](./images/task6.9-createcopypdb2.png " ")
 
-10. Open all of the pluggable databases in the container database **CDB2**.
+10. Open all pluggable databases in the container database **CDB2**.
 
     ```
     <copy>alter pluggable database all open;</copy>
@@ -683,7 +683,7 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
     ![](./images/task6.10-openallpdbs.png " ")
 
-11. Look carefully at the GUID for the two cloned databases.  Since they are cloned from the same unplugged PDB, they are very similar.
+11. Look carefully at the GUID for the two cloned databases. Since they are cloned from the same unplugged PDB, they are very similar.
 
     ```
     <copy>
@@ -696,17 +696,17 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
     ![](./images/task6.11-showguids.png " ")
 
-## Task 7: PDB Hot Clones
-This section looks at how to "hot clone" a pluggable database.  Since Database 12.2, the capability exists to clone a PDB while it is open read write.
+## Task 7: PDB hot clones
+This section looks at how to "hot clone" a pluggable database. Since Database 12.2, the capability exists to clone a PDB while it is open read write.
 
-What you will accomplish in this task:
+What you will do in this task:
 - Create a pluggable database **OE** in the container database **CDB1**
 - Create a load against the pluggable database **OE**
 - Create a hot clone **OE_DEV** in the container database **CDB2** from the pluggable database **OE**
 
 [](youtube:djp-ogM71oE)
 
-If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
+If you are not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
 
     ```
     <copy>sql /nolog
@@ -794,7 +794,7 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
     Leave this window open and running for the next few steps in this lab.
 
-5. Go back to your original terminal window.  Connect to **CDB2** and create the pluggable **OE\_DEV** from the database link **oe@cdb1\_link**.
+5. Go back to your original terminal window. Connect to **CDB2** and create the pluggable **OE\_DEV** from the database link **oe@cdb1\_link**.
 
     ```
     <copy>connect sys/oracle@localhost:1524/cdb2 as sysdba</copy>
@@ -822,7 +822,7 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
     ![](./images/task7.6-rowcountoedev.png " ")
 
-7. Connect as **SOE** to **OE** and check the number of records in the **sale_orders** table.  Since the load script is running against this database, there should be more rows in the table than in the PDB you created as a hot clone of **OE**.
+7. Connect as **SOE** to **OE** and check the number of records in the **sale_orders** table. Since the load script is running against this database, there should be more rows in the table than in the PDB you created as a hot clone of **OE**.
 
     ```
     <copy>connect soe/soe@localhost:1523/oe</copy>
@@ -854,17 +854,17 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
 You can see that the clone of the pluggable database worked without having to stop the load on the source database. In the next step, you will look at how to refresh a clone.
 
-## Task 8: PDB Refresh
+## Task 8: PDB refresh
 This section looks at how to hot clone a pluggable database, open it for read only and then refresh the database.
 
 [](youtube:L9l7v6dH-e8)
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Leverage the **OE** pluggable database from the previous step with the load still running against it.
 - Create a hot clone **OE_REFRESH**` in the container database **CDB2** from the pluggable database **OE**
 - Refresh the **OE_REFRESH**` pluggable database.
 
-If you're not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
+If you are not already running SQLcl, then launch SQLcl and set the formatting to make the on-screen output easier to read.
 
     ```
     <copy>sql /nolog
@@ -942,7 +942,7 @@ If you're not already running SQLcl, then launch SQLcl and set the formatting to
 
 7. Leave the **OE** pluggable database open with the load running against it for the rest of this lab.
 
-## Task 9: PDB Snapshot COPY
+## Task 9: PDB snapshot COPY
 
 You can create a snapshot copy PDB by executing a CREATE PLUGGABLE DATABASE … FROM … SNAPSHOT COPY statement. The source PDB is specified in the FROM clause.
 
@@ -965,7 +965,7 @@ Refreshable PDBs need to be in **read only** mode in order to refresh. You can q
     ```
     ![](./images/task9.1-setenvcdb2.png " ")
 
-2. Launch SQLcl, connect to CDB2 as SYSDBA. Set the SQLcl formatting to make the on-screen output easier to read.  Run the "whoami" script to verify the CDB connection.
+2. Launch SQLcl, connect to CDB2 as SYSDBA. Set the SQLcl formatting to make the on-screen output easier to read. Run the "whoami" script to verify the CDB connection.
     ```
     <copy>
     sql / as sysdba
@@ -1013,7 +1013,7 @@ Refreshable PDBs need to be in **read only** mode in order to refresh. You can q
 
     ![](./images/task9.5-createpdbsnap.png " ")
 
-6. A PDB Snapshot Copy is a "thin" clone that reads from the source PDB but any DML changes will be persisted in the snapshot copy PDB.  Insert a row into the **OE_SNAP** database.
+6. A PDB Snapshot Copy is a "thin" clone that reads from the source PDB but any DML changes will be persisted in the snapshot copy PDB. Insert a row into the **OE_SNAP** database.
 
    ```
    <copy>
@@ -1041,7 +1041,7 @@ Refreshable PDBs need to be in **read only** mode in order to refresh. You can q
 
    ![](./images/task9.7-genhostdu.png " ")
 
-8. Copy and paste separately each of the query output lines to see the difference in disk space consumed between the "thin" PDB Snapshot Copy and the source PDB.
+8. Copy and paste each of the query output lines separately, to see the difference in disk space consumed between the "thin" PDB Snapshot Copy and the source PDB.
 
    ![](./images/task9.8-duoutput.png " ")
 
@@ -1061,16 +1061,16 @@ Refreshable PDBs need to be in **read only** mode in order to refresh. You can q
 
 
 
-## Task 10: PDB Relocation
+## Task 10: PDB relocation
 
-This section looks at how to relocate a pluggable database from one container database to another. One important note: either both container databases need to be using the same listener in order for sessions to keep connecting or local and remote listeners need to be setup correctly. For this lab we will change **CDB2** to use the same listener as **CDB1**.
+This section looks at how to relocate a pluggable database from one container database to another. One important note: either both container databases need to be using the same listener in order for sessions to keep connecting, or local and remote listeners need to be set up correctly. For this lab we will change **CDB2** to use the same listener as **CDB1**.
 
-The tasks you will accomplish in this step are:
+The tasks you will do in this step are:
 - Change **CDB2** to use the same listener as **CDB1**
 - Relocate the pluggable database **OE** from **CDB1** to **CDB2** with the load still running
 - Once **OE** is open the load should continue working
 
-1. In the **other terminal window** that was opened in Lab Task 8, make sure the write-load script is still running.  If not, you may need to restart the shell script.
+1. In the **other terminal window** that was opened in Lab Task 8, make sure the write-load script is still running. If not, you may need to restart the shell script.
 
     ```
     <copy>./write-load.sh </copy>
@@ -1087,7 +1087,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task10.1-changelistener.png " ")
 
-2. Connect to **CDB2** via the shared listener and relocate **OE** using the database link **oe@cdb1_link**.  
+2. Connect to **CDB2** using the shared listener and relocate **OE** using the database link **oe@cdb1_link**.  
 
     ```
     <copy>conn sys/oracle@localhost:1523/cdb2 as sysdba;</copy>
@@ -1113,9 +1113,7 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task10.3-checkcdb1.png " ")
 
-4.  Check the other terminal window where the load program is running.  After a timeout, the load program will resume on its own.  If you don't want to wait, enter CTRL-C to break out of the connection timeout and the load program should continue.  Note that the output now shows it is connected to the database in container **CDB2**.  In real-world scenarios, Oracle customers may be able to leverage **Application Continuity**.  Oracle **Application Continuity** masks outages from end users and applications by recovering the in-flight work for impacted database sessions following outages.  You can learn more about **Application Continuity** [here](https://www.oracle.com/database/technologies/high-availability/app-continuity.html).  
-
-
+4.  Check the other terminal window where the load program is running. After a timeout, the load program will resume on its own. If you don't want to wait, enter CTRL-C to break out of the connection timeout and the load program should continue. Note that the output now shows it is connected to the database in container **CDB2**. In real-world scenarios, Oracle customers may be able to leverage **Application Continuity**. Oracle **Application Continuity** masks outages from end users and applications by recovering the in-flight work for impacted database sessions following outages. You can learn more about **Application Continuity** [at the Oracle Application Continuity web page](https://www.oracle.com/database/technologies/high-availability/app-continuity.html).  
 
     The load program isn't needed anymore, so CTRL-C out of that program and exit from the second terminal window.
 
@@ -1131,9 +1129,9 @@ The tasks you will accomplish in this step are:
 
     ![](./images/task10.5-resetlistener.png " ")
 
-## Lab Cleanup
+## Lab cleanup
 
-1. Exit from the SQL command prompt and reset the container databases back to their original ports. If any errors about dropping databases appear they can be ignored.
+1. Exit from the SQL command prompt and reset the container databases back to their original ports. If any errors about dropping databases appear, you can ignore them.
 
     ```
     <copy>exit
@@ -1146,7 +1144,7 @@ The tasks you will accomplish in this step are:
 
 Now you've had a chance to try out the Multitenant option. You were able to create, clone, plug and unplug a pluggable database. You were then able to accomplish some advanced tasks, such as hot cloning and PDB relocation, that you could leverage to more easily maintain a large multitenant environment.
 
-You may now [proceed to the next lab](#next).
+Please *proceed to the next lab*.
 
 ## Acknowledgements
 

--- a/data-management-library/database/multitenant/intro/intro.md
+++ b/data-management-library/database/multitenant/intro/intro.md
@@ -1,19 +1,19 @@
 # Introduction
 
 ## Oracle Multitenant
-From the point of view of an application, the pluggable database (PDB) is the database, in which applications run unchanged. PDBs can be very rapidly provisioned and a pluggable database is a portable database, which makes it very easy to move around, perhaps for load balancing or migration to the Cloud.
+From the point of view of an application, the pluggable database (PDB) is the database in which applications run unchanged. PDBs can be very rapidly provisioned and a pluggable database is a portable database, which makes it very easy to move around, perhaps for load balancing or migration to the Cloud.
 
 Many PDBs can be plugged into a single Multitenant Container Database (CDB). From the point of view of a Database Administrator (DBA), the CDB is the database. Common operations are performed at the level of the CDB enabling the DBA to manage many as one for operations such as upgrade, configuration of high availability, taking backups; but we retain granular control when appropriate. This ability to manage many as one enables tremendous gains in operational efficiency.
 
-Enormous gains in technical efficiency are enabled by a shared technical infrastructure. There’s a single set of background processes and a single, global memory area – the SGA – shared by all the PDBs. The result is that with this architecture we can consolidate more applications per server.
+Enormous gains in technical efficiency are enabled by a shared technical infrastructure. There’s a single set of background processes and a single, global memory area, the SGA, shared by all the PDBs. The result is that with this architecture we can consolidate more applications per server.
 
-*Estimated Workshop Time*: 4 hours
+Estimated Workshop Time: 4 hours
 
 Watch the video below for an overview of Oracle Multitenant.
 
-[](youtube:4mUwjBfztfU)
+[Overview video on Oracle Multitenant](youtube:4mUwjBfztfU)
 
-### Containers and Pluggable Databases
+### Containers and pluggable databases
 
 A CDB includes zero, one, or many customer-created pluggable databases (PDBs). A PDB is a portable collection of schemas, schema objects, and nonschema objects that appears to an Oracle Net client as a non-CDB. All Oracle databases before Oracle Database 12c were non-CDBs.
 
@@ -28,20 +28,20 @@ Every CDB has the following containers:
 
 The following figure shows a CDB with four containers: the root, seed, and two PDBs. Each PDB has its own dedicated application. A different PDB administrator manages each PDB. A common user exists across a CDB with a single identity. In this example, common user SYS can manage the root and every PDB. At the physical level, this CDB has a database instance and database files, just as a non-CDB does.
 
-![](./images/arch.png " ")
+![Diagram of CDBs and PDBs](./images/arch.png " ")
 
-You may now [proceed to the next lab](#next).
+Please *proceed to the next lab*.
 
-## Learn More
+## Learn more
 
 - Seven Sources of Savings for Companies with Multitenant
-<a href="https://www.youtube.com/watch?v=beB8_jS7Vh0&list=PLdtXkK5KBY55xRePeQfgTOK6rYScVsMcN">![](./images/sevensources.png " ") </a>
+<a href="https://www.youtube.com/watch?v=beB8_jS7Vh0&list=PLdtXkK5KBY55xRePeQfgTOK6rYScVsMcN">![Seven sources of savings](./images/sevensources.png " ") </a>
 
 - Oracle Database Product Management Videos on Multitenant
-<a href="https://www.youtube.com/channel/UCr6mzwq_gcdsefQWBI72wIQ/search?query=multitenant">![](./images/youtube.png " ") </a>
+<a href="https://www.youtube.com/channel/UCr6mzwq_gcdsefQWBI72wIQ/search?query=multitenant">![Product management videos on Multitenant](./images/youtube.png " ") </a>
 
 ## Acknowledgements
 
 - **Authors/Contributors** - Patrick Wheeler, David Start, Vijay Balebail, Kay Malcolm
 - **Contributors** -  Anoosha Pilli, Brian McGraw, Quintin Hill, Rene Fontcha
-- **Last Updated By/Date** - Rene Fontcha, LiveLabs Platform Lead, NA Technology, April 2021
+- **Last Updated By/Date** - Rick Green, Oracle Database User Assistance, October 2021

--- a/data-management-library/database/multitenant/prepare-setup/prepare-setup.md
+++ b/data-management-library/database/multitenant/prepare-setup/prepare-setup.md
@@ -1,9 +1,9 @@
-# Prepare Setup
+# Prepare setup
 
 ## Introduction
 In this lab, you will download the Oracle Resource Manager (ORM) stack zip file needed to setup the resource needed to run this workshop. This workshop requires a compute instance and a Virtual Cloud Network (VCN).
 
-*Estimated Lab Time:* 15 minutes
+Estimated Time: 15 minutes
 
 ### Objectives
 -   Download ORM stack
@@ -15,14 +15,14 @@ This lab assumes you have:
 - SSH Keys
 
 ## Task 1: Download Oracle Resource Manager (ORM) stack zip file
-1.  Click on the link below to download the Resource Manager zip file you need to build your environment: [db-multitenant-mkplc-freetier.zip](https://objectstorage.us-ashburn-1.oraclecloud.com/p/G7LZB2PC1IU-WlBfrsDzKTgqKL9vbyhE5mWrF01MAyD3Gi589C6detaJdbTESF3F/n/natdsecurity/b/stack/o/db-multitenant-mkplc-freetier.zip)
+1.  Click the link below to download the Resource Manager zip file you need to build your environment: [db-multitenant-mkplc-freetier.zip](https://objectstorage.us-ashburn-1.oraclecloud.com/p/G7LZB2PC1IU-WlBfrsDzKTgqKL9vbyhE5mWrF01MAyD3Gi589C6detaJdbTESF3F/n/natdsecurity/b/stack/o/db-multitenant-mkplc-freetier.zip)
 
 2.  Save in your downloads folder.
 
-We strongly recommend using this stack to create a self-contained/dedicated VCN with your instance(s). Skip to *Step 3* to follow our recommendations. If you would rather use an exiting VCN then proceed to the next step as indicated below to update your existing VCN with the required Egress rules.
+We strongly recommend using this stack to create a self-contained/dedicated Virtual Cloud Network (VCN) with your instance(s). Skip to *Step 3* to follow our recommendations. If you would rather use an exiting VCN then proceed to the next step as indicated below to update your existing VCN with the required Egress rules.
 
-## Task 2: Adding Security Rules to an Existing VCN  (Optional) 
-This workshop requires a certain number of ports to be available, a requirement that can be met by using the default ORM stack execution that creates a dedicated VCN. In order to use an existing VCN the following ports should be added to Egress rules
+## Task 2: Add security rules to an existing VCN  (optional)
+This workshop requires a certain number of ports to be available, a requirement that you can meet by using the default ORM stack execution that creates a dedicated VCN. To use an existing VCN, add the following ports to Egress rules:
 
 | Port           |Description                            |
 | :------------- | :------------------------------------ |
@@ -31,10 +31,10 @@ This workshop requires a certain number of ports to be available, a requirement 
 | 1523           | DB Listener                           |
 | 1524           | DB Listener                           |
 
-1.  Go to *Networking >> Virtual Cloud Networks*
+1.  Go to *Networking > Virtual Cloud Networks*
 2.  Choose your network
 3.  Under Resources, select Security Lists
-4.  Click on Default Security Lists under the Create Security List button
+4.  Click Default Security Lists under the Create Security List button
 5.  Click Add Ingress Rule button
 6.  Enter the following:  
     - Source CIDR: 0.0.0.0/0
@@ -44,12 +44,12 @@ This workshop requires a certain number of ports to be available, a requirement 
 ## Task 3: Setup Compute   
 Using the details from the two steps above, proceed to the lab *Environment Setup* to setup your workshop environment using Oracle Resource Manager (ORM) and one of the following options:
   -  Create Stack:  *Compute + Networking*
-  -  Create Stack:  *Compute only* with an existing VCN where security lists have been updated as per *Step 2* above
+  -  Create Stack:  *Compute only* with an existing VCN where security lists have been updated per *Step 2* above
 
-You may now [proceed to the next lab](#next).
+Please *proceed to the next lab*.
 
 ## Acknowledgements
 
 * **Author** - Rene Fontcha, LiveLabs Platform Lead, NA Technology
 * **Contributors** - Meghana Banka, Rene Fontcha, Narayanan Ramakrishnan
-* **Last Updated By/Date** - Kay Malcolm, May 2021
+* **Last Updated By/Date** - Rick Green, Database User Assistance, May 2021


### PR DESCRIPTION
There is a recently discovered bug in SQL Worksheet, in which Lab 4, Task 1, step 9 script fails to create external tables because there are more than 2 begin/end statements within the script. The workaround was to use just a single begin and end for the creation of all 9 external tables. We'll keep this workaround in place until Development fixes the bug.