### PR TITLE
Corrections made as per OHC Learn Guidelines in free tier manifest file

### DIFF
--- a/security-library/oci-security-advisor/workshops/freetier/manifest.json
+++ b/security-library/oci-security-advisor/workshops/freetier/manifest.json
@@ -1,5 +1,5 @@
 {
-  "workshoptitle": "Getting started with Oracle Cloud Infrastructure Security Advisor",
+  "workshoptitle": "Get started with Oracle Cloud Infrastructure Security Advisor",
   "help": "livelabs-help-oci_us@oracle.com",
   "tutorials": [
     {


### PR DESCRIPTION
Corrections made as per OHC Learn Guidelines in free tier manifest file.
Changed workshop title from : "Getting started with Oracle Cloud Infrastructure Security Advisor" to "Get started with Oracle Cloud Infrastructure Security Advisor"