### PR TITLE
updated tittle for WMS 10001 and WMS 10002

### DIFF
--- a/enterprise-manageability-library/enterprise-manager/workshops/desktop-fleet-patching-ui/manifest.json
+++ b/enterprise-manageability-library/enterprise-manager/workshops/desktop-fleet-patching-ui/manifest.json
@@ -1,5 +1,5 @@
 {
-  "workshoptitle": "Oracle Enterprise Manager - Automated Database Patching at Scale with Fleet Maintenance",
+  "workshoptitle": "Oracle Enterprise Manager - Automated Database Patching at Scale with Fleet Maintenance UI",
   "help": "livelabs-help-mgmt_us@oracle.com",
   "tutorials": [
     {

--- a/enterprise-manageability-library/enterprise-manager/workshops/desktop-fleet-upgrade-ui/manifest.json
+++ b/enterprise-manageability-library/enterprise-manager/workshops/desktop-fleet-upgrade-ui/manifest.json
@@ -1,5 +1,5 @@
 {
-  "workshoptitle": "Oracle Enterprise Manager - Automated Database Upgrade at Scale with Fleet Maintenance",
+  "workshoptitle": "Oracle Enterprise Manager - Automated Database Upgrade at Scale with Fleet Maintenance UI",
   "help": "livelabs-help-mgmt_us@oracle.com",
   "tutorials": [
     {

--- a/enterprise-manageability-library/enterprise-manager/workshops/freetier-fleet-patching-ui/manifest.json
+++ b/enterprise-manageability-library/enterprise-manager/workshops/freetier-fleet-patching-ui/manifest.json
@@ -1,5 +1,5 @@
 {
-  "workshoptitle": "Oracle Enterprise Manager - Automated Database Patching at Scale with Fleet Maintenance",
+  "workshoptitle": "Oracle Enterprise Manager - Automated Database Patching at Scale with Fleet Maintenance UI",
   "help": "livelabs-help-mgmt_us@oracle.com",
   "tutorials": [
     {

--- a/enterprise-manageability-library/enterprise-manager/workshops/freetier-fleet-upgrade-ui/manifest.json
+++ b/enterprise-manageability-library/enterprise-manager/workshops/freetier-fleet-upgrade-ui/manifest.json
@@ -1,5 +1,5 @@
 {
-  "workshoptitle": "Oracle Enterprise Manager - Automated Database Upgrade at Scale with Fleet Maintenance",
+  "workshoptitle": "Oracle Enterprise Manager - Automated Database Upgrade at Scale with Fleet Maintenance UI",
   "help": "livelabs-help-mgmt_us@oracle.com",
   "tutorials": [
     {


### PR DESCRIPTION
Found that under workshop , both desktop and freetier manifest.json had old workshop tittle.. Updated it to showcase UI. 
WMS ids are WMS 10001 and WMS 10002